### PR TITLE
many updates to workflow progress reporting, general code syntax

### DIFF
--- a/R/Allclasses.R
+++ b/R/Allclasses.R
@@ -32,4 +32,3 @@ setClass(Class="tssExp",
              tsrDataMerged = data.frame()
              ),
          )
-            

--- a/R/Show-methods.R
+++ b/R/Show-methods.R
@@ -1,33 +1,30 @@
 # Show methods for TSRchitect
       
 setMethod("show",
-          signature(object= "tssExp"),
+          signature(object="tssExp"),
           function(object) {
               cat("############################################\n")
               cat("############## TSRchitect ##################\n")
               cat("       Object of Class 'tssExp'\n")
-              cat("############################################\n")
-              cat("Title of Experiment:", object@title,"\n")
-              cat("TSS data is:", object@dataType, "\n")
+              cat("############################################\n\n")
+              cat("Title of experiment:", object@title,"\n\n")
+              cat("The TSS data were specified to be \"", object@dataType, "\"\n")
               if (length(object@fileNames) > 0) {
-                  message("\nThe following bam files are loaded:\n")
+                  cat("and to be contained in the following files:\n")
                   for (i in 1:length(object@fileNames)) {
                       cat(paste(object@fileNames[i]),sep="\n")
                   }
               }
               else {
-                  message("\nNo bam files loaded.\n")
+                  stop("\nNo *.bam files were found.  Please check.\n")
               }
               if (length(object@tssData) > 0) {
-                message("\nThere are:")
-                cat(length(object@tssData))
-                message(" tss datasets loaded in this object\n\n")
-            }
+                  cat("\n")
+                  cat(length(object@tssData))
+                  cat(" tss datasets were loaded into the tssExp object \"", deparse(substitute(object)), "\".\n")
+              }
               else {
-                message("\nNo tss data loaded.\n")
-            }
+                  cat("\nNo tss data have been loaded.\n")
+              }
           }
           )
-
-
-                  

--- a/R/bamToTSS.R
+++ b/R/bamToTSS.R
@@ -1,7 +1,7 @@
 #' bamToTSS
 #' Extracts TSS information from each bam file in a tssExp object
-#' @param expName an object of tssExp format containing bam files
-#' @return creates a list of TSSs in class GRanges for each bam file contained within expName, and places them in the tssExp object
+#' @param expName - a S4 object of class tssExp with bam files loaded
+#' @return creates a list of TSSs in class GRanges for each bam file contained within expName and places them in the tssExp object
 #' @importFrom GenomicRanges granges GRanges GRangesList
 #' @importFrom BiocGenerics start end
 #' @importFrom GenomeInfoDb sortSeqlevels
@@ -20,19 +20,19 @@ setMethod("bamToTSS",
           function(expName) {
               object.name <- deparse(substitute(expName))
 
+              message("... bamToTSS ...")
               if (length(expName@bamData) == 0) {
                   stop("Slot @bamData is empty.\n\n Please load alignment files to your tssExp object.")
               }
-
-              if (length(expName@bamData) > 0) {
-                  cat("Beginning TSS conversion progress.\n\n")
+              else {
+                  cat("\nBeginning .bam read alignment to TSS data conversion ...\n\n")
               }
 
               bam.len <- length(expName@bamData)
               bam.vec <- vector(mode="list", length=bam.len)
                             
               for (i in 1:bam.len) {
-                 cat("Retrieving bam #", i, "...\n\n")
+                 cat("Retrieving data from bam file #", i, "...\n\n")
                  expName@bamData[[i]] -> bam.data
                   as(bam.data,"data.frame") -> bam.df
                   bam.df[bam.df$strand=="+",] -> df.plus
@@ -55,12 +55,14 @@ setMethod("bamToTSS",
                         sortSeqlevels(gr.combined) -> gr.combined
                         sort(gr.combined) -> gr.combined
                         gr.combined -> bam.vec[[i]] 
-             }
+              }
 
               GR.list <- GRangesList(bam.vec)
               expName@tssData <- GR.list
               expName@expData <- vector(mode="list", length=bam.len)
-              message("\nTSS data from ", bam.len, " separate bam files were successfully added to your tssExp object.\n\n")
+              cat("Done. TSS data from ", bam.len, " separate bam files have been successfully added to\ntssExp object \"", object.name, "\".\n\n")
+              cat("--------------------------------------------------------------------------------\n")
               assign(object.name, expName, envir = parent.frame())
-           }
+              message(" Done.\n")
+          }
           )         

--- a/R/clustering-functions.R
+++ b/R/clustering-functions.R
@@ -86,7 +86,7 @@ setMethod("acquireTSS",
 #' @importFrom gtools mixedsort
 #' @export
 
-expressionCTSS <- function(x, writeDF=TRUE, dfName="CTSS.txt") {
+expressionCTSS <- function(x, dfName="CTSS.txt", writeDF=TRUE) {
         #starting with the plus strand
         my.matrix <- matrix(NA, nrow=1, ncol=4)
         n.chr <- length(names(x)) # how many chromosomes are there in the TSS list?
@@ -133,6 +133,7 @@ expressionCTSS <- function(x, writeDF=TRUE, dfName="CTSS.txt") {
 
         if (writeDF==TRUE) {
             write.table(my.df, dfName, quote=FALSE, col.names=TRUE, row.names=FALSE, sep="\t")
+            message("\nThe TSS dataset has been written to file ", dfName, "\nin your working directory.")
         }
 
         return(my.df)

--- a/R/importBam.R
+++ b/R/importBam.R
@@ -1,5 +1,5 @@
-#' Computes TSS positions from all bam files and loads them onto a tssExp object
-#' @param expName an S4 object of class tssExp that contains information about the experiment.
+#' Computes TSS positions from all bam files and loads them into a tssExp object
+#' @param expName - a S4 object of class tssExp that contains information about the experiment
 #' @importFrom BiocParallel bplapply MulticoreParam
 #' @importFrom GenomicAlignments readGAlignments
 #' @importFrom Rsamtools scanBamFlag ScanBamParam BamViews
@@ -19,15 +19,15 @@ setMethod("importBam",
               expName.chr <- deparse(substitute(expName))
               exp.type <- expName@dataType
 
-             if(exp.type=="pairedEnd") {
+              message("... importBam ...")
+              if(exp.type=="pairedEnd") {
                   scanBamFlag(isPaired=TRUE, isProperPair=TRUE, isUnmappedQuery=FALSE) -> bamFlags
-                  cat("\nPaired-end TSS data specified.")
+                  cat("\nTSS data were specified to be paired-end read alignments.")
                   c("rname","strand","pos","qwidth", "mapq", "isize") -> myFields
               }
-                                     
               else {
                   scanBamFlag(isPaired=FALSE, isProperPair=FALSE, isUnmappedQuery=FALSE) -> bamFlags
-                  cat("\nSingle-end TSS data specified.\n")
+                  cat("\nTSS data were specified to be single-end read alignments.\n")
                   c("rname","strand","pos", "qwidth", "mapq") -> myFields
               }
 
@@ -36,11 +36,12 @@ setMethod("importBam",
               bv_obj <- BamViews(bam.paths)
               bv_files <- dimnames(bv_obj)[[2]]
               n.bams <- length(bv_files)
-              message("\nBegan import of ", n.bams, " bam files.\n")
+              cat("\nBeginning import of ", n.bams, " bam files ...\n")
               bams.GA <- bplapply(bam.paths, readGAlignments, BPPARAM = MulticoreParam(),param=my.param)
               expName@bamData <- bams.GA
-              message("\nImport complete!\n")
-              message("\nAlignment data from ", n.bams, " bams have been attached to your tssExp object.\n")
+              cat("Done. Alignment data from ", n.bams, " bam files have been attached to tssExp\nobject \"", expName.chr, "\".\n")
+              cat("--------------------------------------------------------------------------------\n")
               assign(expName.chr, expName, parent.frame()) 
+              message(" Done.\n")
           }
           )

--- a/R/initializeExp.R
+++ b/R/initializeExp.R
@@ -1,55 +1,54 @@
 #' Initializes the TSS profiling experiment
-#' @param expTitle a title for the experiment (character)
-#' @param objName a name the object to be created in your working environment (character)
-#' @param expDir a path to the directory with the alignment files in bam format (character)
-#' @param isPairedEnd a logical indicating whether the TSS profiling experiment was paired-end (logical)
+#' @param expTitle    - title for the experiment (character)
+#' @param expName     - name for the tssExp object to be created in your working environment (character)
+#' @param expDir      - path to the directory with the alignment files in bam format (character)
+#' @param isPairedEnd - TRUE/FALSE according to whether the TSS profiling experiment was paired-end or not (logical)
 #' @return Creates a tssExp object in the user's current workspace.
 #' @export 
 
 setGeneric(
     name="initializeExp",
-    def=function(expTitle, objName, expDir, isPairedEnd) {
+    def=function(expTitle, expName, expDir, isPairedEnd) {
         standardGeneric("initializeExp")
     }
     )
 
 setMethod("initializeExp",
-          signature(expTitle="character", objName="character", expDir="character", isPairedEnd="logical"),
-          function(expTitle, objName, expDir, isPairedEnd) {
+          signature(expTitle="character", expName="character", expDir="character", isPairedEnd="logical"),
+          function(expTitle, expName, expDir, isPairedEnd) {
               tssObj <- new("tssExp")
-              
-              if (is.na(expTitle)) {
-                  stop("Argument 'expTitle' is empty. Please supply a title for your experiment.")
+
+              message("... initializeExp ...")
+              if (expTitle == "") {
+                  stop("Argument 'expTitle' of initializeExp() is empty.\n  Please provide a title for your experiment.")
               }
 
-              if (is.na(objName)) {
-                  stop("Argument 'objName' is empty. Please supply a name for the tssExp object.")
-                   }
+              if (expName == "") {
+                  stop("Argument 'expName' of initializeExp() is empty.\n  Please specify a name for the tssExp object.")
+              }
 
-              if (is.na(expDir)) {
-                stop("Argument 'expDir' is empty. Please supply the full paths location of the alignment files (BAMs) for this experiment.")
-             }
+              if (expDir == "") {
+                  stop("Argument 'expDir' of initializeExp() is empty.\n  Please supply the name of the directory containing the read alignment files (in .bam format) for this experiment.")
+              }
               
               if (isPairedEnd==TRUE) {
                   tssObj@dataType <- c("pairedEnd")
               }
-
               else {
                   tssObj@dataType <- c("singleEnd")
               }
 
-              tss_files <- list.files(expDir, pattern="\\.bam$", all.files=FALSE,full.names=TRUE)
+              tss_files <- list.files(expDir, pattern="\\.bam$", all.files=FALSE, full.names=TRUE)
 
               if (length(tss_files) < 1) {
-                  stop("There are no .bam files in the directory you supplied, or the directory itself does not exist.\n Please correct your input for 'expDir'.")
+                  stop("There are no .bam files in the directory you specified, or the directory itself does not exist.\n  Please check your input for argument 'expDir' of initializeExp().")
               }
 
               tssObj@title <- expTitle
               tssObj@fileNames <- tss_files
-              message("The tssExp object: ", objName, " is now in your workspace. \n")
-              assign(objName, tssObj, parent.frame()) 
+              cat("\nThe tssExp object \"", expName, "\" has been initialized in your workspace.\n")
+              cat("--------------------------------------------------------------------------------\n")
+              assign(expName, tssObj, parent.frame()) 
+              message(" Done.\n")
           }
           )
-
-              
-  

--- a/R/tsrFind.R
+++ b/R/tsrFind.R
@@ -1,9 +1,9 @@
 #' tsrFind
 #' Finds TSRs from a given chromosome
-#' @param expName an object of tssExp format containing information in slot tssData
-#' @param tssNum the number of the dataset to be analyzed
-#' @param nTSSs the number of TSSs required at a given position
-#' @param clustDist the maximum distance of TSSs between two TSRs (in base pairs)
+#' @param expName - a S4 object of class tssExp containing information in slot tssData
+#' @param tssNum - number of the dataset to be analyzed
+#' @param nTSSs - number of TSSs required at a given position
+#' @param clustDist - maximum distance of TSSs between two TSRs (in base pairs)
 #' @return creates a list of GenomicRanges containing TSR positions in slot 'tsrData' on your tssExp object
 #' @export 
 
@@ -19,31 +19,27 @@ setMethod("tsrFind",
 
           function(expName, tssNum, nTSSs, clustDist, writeTable) {
               object.name <- deparse(substitute(expName))
-              message("\nInitiated TSR finding.")
 
+              message("... tsrFind ...")
               if (tssNum>length(expName@expData)) {
-                  stop("The value selected exceeds the number of slots in tssData.")
+                  stop("The value selected for tssNum exceeds the number of slots in tssData.")
               }
               
               tss.mat <- expName@expData[[tssNum]]
-              message("Clustering TSS expression matrix into TSR regions.\n")
               tsr.list <- .tsrCluster(tss.mat, expThresh=nTSSs, minDist=clustDist)
-              message("Clustering complete.\n")
               tsr.DF <- tsrToDF(tsr.list)
 
               if (writeTable=="TRUE") {
-              df.name <- paste("CTSS", tssNum, sep="")
-              df.name <- paste(df.name, "txt", sep=".")
-              write.table(tsr.DF, file=df.name, col.names=FALSE, row.names=FALSE, sep="\t", quote=FALSE)
-              message("\nA data frame containing TSRs was written to your current working directory.")
+                  df.name <- paste("TSRset-", tssNum, sep="")
+                  df.name <- paste(df.name, "txt", sep=".")
+                  write.table(tsr.DF, file=df.name, col.names=FALSE, row.names=FALSE, sep="\t", quote=FALSE)
+                  message("\nThe TSR set for TSS dataset ", tssNum, " has been written to file ", df.name, "\nin your working directory.")
               }
 
               expName@tsrData <- tsr.DF
-              message("\nTSRs were successfully added to your tssExp object.\n")
+              cat("\n... the TSR dataframe tsrData for dataset ", tssNum, " has been successfully added to\ntssExp object \"", object.name, "\"\n")
+              cat("--------------------------------------------------------------------------------\n")
               assign(object.name, expName, envir = parent.frame())              
+              message(" Done.\n")
           }
           )
-              
-
-
-          

--- a/R/tssExpr.R
+++ b/R/tssExpr.R
@@ -1,7 +1,7 @@
 #' tssExpr
 #' Creates an expression matrix for all TSSs within a given TSS experiment (in tssData)
-#' @param expName an object of tssExp format containing information in slot tssData
-#' @param tssNum the number of the dataset to be analyzed
+#' @param expName - a S4 object of class tssExp containing information in slot tssData
+#' @param tssNum - number of the dataset to be analyzed
 #' @param writeTable if TRUE, writes a data frame containing the TSSs positions and their abundance to your workspace
 #' @return creates a data frame containing tss expression for each CTSS in slot 'tssExpr' on your tssExp object
 #' @export 
@@ -19,26 +19,27 @@ setMethod("tssExpr",
           function(expName, tssNum, writeTable) {
               object.name <- deparse(substitute(expName))
 
+              message("... tssExpr ...")
               if (tssNum>length(expName@tssData)) {
                   stop("The value selected exceeds the number of slots in tssData.")
               }
               
               tss <- acquireTSS(expName, tssNum)
-              message("\nCreating expression matrix for dataset ", tssNum, "...\n")
 
-              df.name <- paste("CTSS", tssNum, sep="")
+              df.name <- paste("CTSSset-", tssNum, sep="")
               df.name <- paste(df.name, "txt", sep=".")              
 
               if (writeTable=="TRUE") {
-              tss.mat <- expressionCTSS(tss, dfName=df.name, writeDF=TRUE)
+                  tss.mat <- expressionCTSS(tss, dfName=df.name, writeDF=TRUE)
               }
-
               else {
-              tss.mat <- expressionCTSS(tss, dfName="my.df", writeDF=FALSE)
+                  tss.mat <- expressionCTSS(tss, dfName="my.df", writeDF=FALSE)
               }
 
               expName@expData[[tssNum]] <- tss.mat
-              message("\nA TSS expression matrix was successfully added to your tssExp object.\n")
+              cat("\n... the TSS expression matrix for dataset ", tssNum, " has been successfully added to\ntssExp object \"", object.name, "\"\n")
+              cat("--------------------------------------------------------------------------------\n")
               assign(object.name, expName, envir = parent.frame())              
+              message(" Done.\n")
           }
           )


### PR DESCRIPTION
I added consistent handling of reporting messages:

message() like stop() goes to stderr, whereas cat() goes to stdout.  We should have progress notes on stderr, but record keeping in stdout.  Now we can run TSRchitect commands with Rscript from a file x as follows:
Rscript --default-packages=methods,utils,stats x > output

which will show progress on stderr, while keeping other messages in file output.

I also made some changes for consistency, most importantly using expName as second argument for initializeExp, as we do in all other places.  Output files for tsrFind are properly names TSRset-x.txt, to go along with CTSSset-x.txt from tssExpr.R.