### PR TITLE
Update to setSampleID; other various minor updates

### DIFF
--- a/R/addAnnotationToTSR.R
+++ b/R/addAnnotationToTSR.R
@@ -44,8 +44,8 @@
 #' featureColumnID="ID", writeTable=FALSE)
 #' #if the object attached to @@annotation is a gff/gff3 file
 #' 
-#' @note An example similar to the this one can be found in \emph{Example 1}
-#' from the vignette (/inst/doc/TSRchitect.Rmd)
+#' @note An example similar to the this one can be found
+#' in the vignette (/inst/doc/TSRchitect.Rmd)
 #' 
 #' @export
 

--- a/R/addTagCountsToTSR.R
+++ b/R/addTagCountsToTSR.R
@@ -25,7 +25,7 @@
 #' tsrSet=1, tagCountThreshold=25, writeTable=FALSE)
 #' 
 #' @note An example similar to the one provided can be found in
-#' \emph{Example 1} from the vignette (/inst/doc/TSRchitect.Rmd)
+#' the vignette (/inst/doc/TSRchitect.Rmd)
 #' 
 #' @export
 

--- a/R/bamToTSS.R
+++ b/R/bamToTSS.R
@@ -19,8 +19,7 @@
 #' bamToTSS(experimentName=tssObjectExample)
 #' 
 #' @note An example similar to the one provided can be
-#' found in \emph{Example 1} from the vignette
-#' (/inst/doc/TSRchitect.Rmd).
+#' found in the vignette (/inst/doc/TSRchitect.Rmd).
 #' 
 #' @export
 

--- a/R/determineTSR.R
+++ b/R/determineTSR.R
@@ -1,35 +1,49 @@
 #' @title \strong{determineTSR}
-#' @description \code{determineTSR} Identifies TSRs from entire TSS datasets as specified.
+#' @description \code{determineTSR} Identifies TSRs from
+#' entire TSS datasets as specified.
 #' 
-#' @param experimentName an object of class \emph{tssObject} containing information in slot \emph{@@tssTagData}
+#' @param experimentName an object of class \emph{tssObject}
+#' containing information in slot \emph{@@tssTagData}
 #' @param parallel if TRUE, the analysis is run in parallel (logical)
-#' @param tsrSetType specifies the set to be clustered. Options are "replicates" or "merged". (character)
-#' @param tssSet default is "all"; if a single TSS dataset is desired, specify tssSet number (character)
-#' @param tagCountThreshold the number of TSSs required at a given position for it to be considered in TSR identification. (numeric)
-#' @param clustDist the maximum distance of TSSs between two TSRs in base pairs. (numeric)
-#' @param writeTable specifies whether the output should be written to a table. (logical)
+#' @param tsrSetType specifies the set to be clustered.
+#' Options are "replicates" or "merged". (character)
+#' @param tssSet default is "all"; if a single TSS dataset is desired,
+#' specify tssSet number (character)
+#' @param tagCountThreshold the number of TSSs required at a given position
+#' for it to be considered in TSR identification. (numeric)
+#' @param clustDist the maximum distance of TSSs between two
+#' TSRs in base pairs. (numeric)
+#' @param writeTable specifies whether the output should
+#' be written to a table. (logical)
 #'
-#' @return creates a list of \linkS4class{GenomicRanges}-containing TSR positions in slot \emph{@@tsrData} on the \emph{tssObject} object
+#' @return creates a list of \linkS4class{GenomicRanges}-containing
+#' TSR positions in slot \emph{@@tsrData} on the \emph{tssObject} object
 #'  
 #' @examples
 #' load(system.file("extdata", "tssObjectExample.RData", package="TSRchitect"))
-#' determineTSR(experimentName=tssObjectExample, parallel=FALSE, tsrSetType="replicates", tssSet="1", tagCountThreshold=25, clustDist=20, writeTable=FALSE)
+#' determineTSR(experimentName=tssObjectExample, parallel=FALSE,
+#' tsrSetType="replicates", tssSet="1", tagCountThreshold=25,
+#' clustDist=20, writeTable=FALSE)
 #' 
-#' @note An example similar to this one can be found in \emph{Example 1} from the vignette (/inst/doc/TSRchitect.Rmd)
+#' @note An example similar to this one can be found in the vignette
+#' (/inst/doc/TSRchitect.Rmd)
 
 #' @export
 
 setGeneric(
            name="determineTSR",
-           def=function(experimentName, parallel, tsrSetType, tssSet, tagCountThreshold, clustDist, writeTable=FALSE) {
+    def=function(experimentName, parallel, tsrSetType, tssSet,
+        tagCountThreshold, clustDist, writeTable=FALSE) {
                standardGeneric("determineTSR")
     }
     )
 
 setMethod("determineTSR",
-          signature(experimentName="tssObject", "logical", "character", "character", "numeric", "numeric", "logical"),
+          signature(experimentName="tssObject", "logical", "character",
+                    "character", "numeric", "numeric", "logical"),
 
-          function(experimentName, parallel=TRUE, tsrSetType, tssSet="all", tagCountThreshold=1, clustDist=20, writeTable=FALSE) {
+          function(experimentName, parallel=TRUE, tsrSetType, tssSet="all",
+                   tagCountThreshold=1, clustDist=20, writeTable=FALSE) {
              object.name <- deparse(substitute(experimentName))
 
              message("... determineTSR ...")
@@ -37,16 +51,35 @@ setMethod("determineTSR",
                  if (tssSet=="all") {
                      iend <- length(experimentName@tssCountData)
                      if (parallel==TRUE) {
-                         experimentName@tsrData <- foreach(i=1:iend,.packages="TSRchitect") %dopar% detTSR(experimentName = experimentName, tsrSetType="replicates", tssSet=i, tagCountThreshold, clustDist)
+                         experimentName@tsrData <- foreach(i=1:iend,
+                                      .packages="TSRchitect") %dopar% 
+                                                      detTSR(experimentName =
+                                                      experimentName,
+                                                      tsrSetType="replicates",
+                                                      tssSet=i, 
+                                                      tagCountThreshold,
+                                                      clustDist)
                          if (writeTable=="TRUE") {
-                             foreach(i=1:iend,.packages="TSRchitect") %dopar% writeTSR(experimentName = experimentName, tsrSetType="replicates", tsrSet=i, fileType="tab")
+                             foreach(i=1:iend,.packages="TSRchitect") %dopar%
+                                 writeTSR(experimentName = experimentName,
+                                 tsrSetType="replicates",
+                                 tsrSet=i,
+                                 fileType="tab")
                          }
                      }
                      else {
                          for (i in 1:iend) {
-                             experimentName@tsrData[[i]] <- detTSR(experimentName = experimentName, tsrSetType="replicates", tssSet=i, tagCountThreshold, clustDist)
+                             experimentName@tsrData[[i]] <-
+                                 detTSR(experimentName = experimentName,
+                                        tsrSetType="replicates",
+                                        tssSet=i,
+                                        tagCountThreshold,
+                                        clustDist)
                              if (writeTable=="TRUE") {
-                                 writeTSR(experimentName = experimentName, tsrSetType="replicates", tsrSet=i, fileType="tab")
+                                 writeTSR(experimentName = experimentName,
+                                          tsrSetType="replicates",
+                                          tsrSet=i,
+                                          fileType="tab")
                              }
                          }
                      }
@@ -54,11 +87,20 @@ setMethod("determineTSR",
                  else {
                      i <- as.numeric(tssSet)
                      if (i>length(experimentName@tssCountData)) {
-                         stop("The value selected for tssSet exceeds the number of slots in tssCountData.")
+                         stop("The value selected for tssSet",
+                              "exceeds the number of slots in tssCountData.")
                      }
-                     experimentName@tsrData[[i]] <- detTSR(experimentName = experimentName, tsrSetType="replicates", tssSet=i, tagCountThreshold, clustDist)
+                     experimentName@tsrData[[i]] <-
+                         detTSR(experimentName = experimentName,
+                                tsrSetType="replicates",
+                                tssSet=i,
+                                tagCountThreshold,
+                                clustDist)
                      if (writeTable=="TRUE") {
-                         writeTSR(experimentName = experimentName, tsrSetType="replicates", tsrSet=i, fileType="tab")
+                         writeTSR(experimentName = experimentName,
+                                  tsrSetType="replicates",
+                                  tsrSet=i,
+                                  fileType="tab")
                      }
                  }
              }
@@ -67,16 +109,36 @@ setMethod("determineTSR",
                  if (tssSet=="all") {
                      iend <- length(experimentName@tssCountDataMerged)
                      if (parallel==TRUE) {
-                         experimentName@tsrDataMerged <- foreach(i=1:iend,.packages="TSRchitect") %dopar% detTSR(experimentName = experimentName, tsrSetType="merged", tssSet=i, tagCountThreshold, clustDist)
+                         experimentName@tsrDataMerged <-
+                             foreach(i=1:iend,.packages="TSRchitect") %dopar%
+                                 detTSR(experimentName =
+                                 experimentName,
+                                 tsrSetType="merged",
+                                 tssSet=i,
+                                 tagCountThreshold,
+                                 clustDist)
                          if (writeTable=="TRUE") {
-                             foreach(i=1:iend,.packages="TSRchitect") %dopar% writeTSR(experimentName = experimentName, tsrSetType="merged", tsrSet=i, fileType="tab")
+                             foreach(i=1:iend,.packages="TSRchitect") %dopar%
+                                 writeTSR(experimentName =
+                                 experimentName,
+                                 tsrSetType="merged",
+                                 tsrSet=i,
+                                 fileType="tab")
                          }
                      }
                      else {
                          for (i in 1:iend) {
-                             experimentName@tsrDataMerged[[i]] <- detTSR(experimentName = experimentName, tsrSetType="merged", tssSet=i, tagCountThreshold, clustDist)
+                             experimentName@tsrDataMerged[[i]] <-
+                                 detTSR(experimentName = experimentName,
+                                        tsrSetType="merged",
+                                        tssSet=i,
+                                        tagCountThreshold,
+                                        clustDist)
                              if (writeTable=="TRUE") {
-                                 writeTSR(experimentName = experimentName, tsrSetType="merged", tsrSet=i, fileType="tab")
+                                 writeTSR(experimentName = experimentName,
+                                          tsrSetType="merged",
+                                          tsrSet=i,
+                                          fileType="tab")
                              }
                          }
                      }
@@ -84,19 +146,29 @@ setMethod("determineTSR",
                  else {
                      i <- as.numeric(tssSet)
                      if (i>length(experimentName@tssCountDataMerged)) {
-                         stop("The value selected for tssSet exceeds the number of slots in tssCountDataMerged.")
+                         stop("The value selected for tssSet exceeds",
+                              "the number of slots in tssCountDataMerged.")
                      }
-                     experimentName@tsrDataMerged[[i]] <- detTSR(experimentName = experimentName, tsrSetType="merged", tssSet=i, tagCountThreshold, clustDist)
+                     experimentName@tsrDataMerged[[i]] <-
+                         detTSR(experimentName = experimentName,
+                                tsrSetType="merged",
+                                tssSet=i,
+                                tagCountThreshold,
+                                clustDist)
                      if (writeTable=="TRUE") {
-                         writeTSR(experimentName = experimentName, tsrSetType="merged", tsrSet=i, fileType="tab")
+                         writeTSR(experimentName = experimentName,
+                                  tsrSetType="merged",
+                                  tsrSet=i,
+                                  fileType="tab")
                      }
                  }
              }
 
              else {
-                 stop("Error: argument tsrSetType to determineTSR() should be either \"replicates\" or \"merged\".")
+                 stop("Error: argument tsrSetType should be",
+                      "either \"replicates\" or \"merged\".")
              }
-             cat("--------------------------------------------------------------------------------\n")
+             cat("---------------------------------------------------------\n")
              assign(object.name, experimentName, envir = parent.frame())
              message(" Done.\n")
           }

--- a/R/importAnnotationHub.R
+++ b/R/importAnnotationHub.R
@@ -19,7 +19,7 @@
 #' @importFrom AnnotationHub AnnotationHub query
 #'
 #' @note An example similar to the one provided can be found in
-#' \emph{Example 1} from the vignette (/inst/doc/TSRchitect.Rmd)
+#' the vignette (/inst/doc/TSRchitect.Rmd)
 #' @note Please consult the available records in AnnotationHub
 #' beforehand using \code{\link[AnnotationHub]{AnnotationHub}}
 #'

--- a/R/mergeSampleData.R
+++ b/R/mergeSampleData.R
@@ -17,7 +17,7 @@
 #' mergeSampleData(experimentName=tssObjectExample)
 #' 
 #' @note An example similar to the one provided can be found in
-#' \emph{Example 1} from the vignette (/inst/doc/TSRchitect.Rmd).
+#' the vignette (/inst/doc/TSRchitect.Rmd).
 #' @export
 
 setGeneric(

--- a/R/processTSS.R
+++ b/R/processTSS.R
@@ -22,7 +22,7 @@
 #' @note Note that the \emph{tssSet} parameter must be of class
 #' \emph{character}, even when selecting an individual dataset.
 #' @note An example similar to the one provided can be found in
-#' \emph{Example 1} from the vignette (/inst/doc/TSRchitect.Rmd).
+#' the vignette (/inst/doc/TSRchitect.Rmd).
 #' 
 #' @export
 

--- a/R/setSampleID.R
+++ b/R/setSampleID.R
@@ -6,9 +6,6 @@
 #' contains information about the experiment.
 #' @param sample.names unique labels of class character for each TSS sample
 #' within the experiment.
-#' Please note that \code{importBam} attaches .bam data in ascending
-#' alphanumeric order, so \emph{sample.names} must be arranged in this order
-#' also so that they directly correspond to the intended file.
 #' @param replicate.IDs identifiers indicating which samples are biological
 #' replicates. As with \emph{sample.names}, note that \code{importBam} imports
 #' bam data in ascending alphanumeric order, so replicate.IDs must be arranged
@@ -25,8 +22,11 @@
 #' replicate.IDs=c(1,1,2,2))
 #' #experiments 1 & 2 and 3 & 4 are replicates of samples 1 and 2, respectively
 #' 
-#' @note An example similar to the one provided can be found in
-#' \emph{Example 1} from the vignette (/inst/doc/TSRchitect.Rmd)
+#' @note
+#' Please note that \code{importBam} attaches .bam data in ascending
+#' alphanumeric order, so \emph{sample.names} must be arranged in such
+#' a way that they directly correspond to the intended file.
+#' This order can be specified using \code{\link{getFileNames}}
 #' 
 #' @export
 
@@ -45,12 +45,6 @@ setMethod("setSampleID",
               exp.len <- length(experimentName@fileNames)
 
               message("... setSampleID ...")
-              if (exp.len!=length(sample.names) || 
-                  exp.len!=length(replicate.IDs)) {
-                  stop("\nThe number of sample names and replicate IDs",
-                       "must be equal to the number of file names in your",
-                       "tssObject object.")
-              }
 
               if (length(sample.names)!=(length(replicate.IDs))) {
                   stop("\nsample.names and replicate.IDs must have",

--- a/man/addAnnotationToTSR.Rd
+++ b/man/addAnnotationToTSR.Rd
@@ -50,8 +50,8 @@ with a given gene, if found upstream and on the same strand within
 a specified range.
 }
 \note{
-An example similar to the this one can be found in \emph{Example 1}
-from the vignette (/inst/doc/TSRchitect.Rmd)
+An example similar to the this one can be found
+in the vignette (/inst/doc/TSRchitect.Rmd)
 }
 \examples{
 load(system.file("extdata", "tssObjectExample.RData",

--- a/man/addTagCountsToTSR.Rd
+++ b/man/addTagCountsToTSR.Rd
@@ -34,7 +34,7 @@ of identified TSRs
 }
 \note{
 An example similar to the one provided can be found in
-\emph{Example 1} from the vignette (/inst/doc/TSRchitect.Rmd)
+the vignette (/inst/doc/TSRchitect.Rmd)
 }
 \examples{
 load(system.file("extdata", "tssObjectExample.RData", package="TSRchitect"))   

--- a/man/bamToTSS.Rd
+++ b/man/bamToTSS.Rd
@@ -20,8 +20,7 @@ attached .bam file in a tssObject object
 }
 \note{
 An example similar to the one provided can be
-found in \emph{Example 1} from the vignette
-(/inst/doc/TSRchitect.Rmd).
+found in the vignette (/inst/doc/TSRchitect.Rmd).
 }
 \examples{
 load(system.file("extdata", "tssObjectExample.RData",

--- a/man/determineTSR.Rd
+++ b/man/determineTSR.Rd
@@ -8,32 +8,43 @@ determineTSR(experimentName, parallel, tsrSetType, tssSet, tagCountThreshold,
   clustDist, writeTable = FALSE)
 }
 \arguments{
-\item{experimentName}{an object of class \emph{tssObject} containing information in slot \emph{@tssTagData}}
+\item{experimentName}{an object of class \emph{tssObject}
+containing information in slot \emph{@tssTagData}}
 
 \item{parallel}{if TRUE, the analysis is run in parallel (logical)}
 
-\item{tsrSetType}{specifies the set to be clustered. Options are "replicates" or "merged". (character)}
+\item{tsrSetType}{specifies the set to be clustered.
+Options are "replicates" or "merged". (character)}
 
-\item{tssSet}{default is "all"; if a single TSS dataset is desired, specify tssSet number (character)}
+\item{tssSet}{default is "all"; if a single TSS dataset is desired,
+specify tssSet number (character)}
 
-\item{tagCountThreshold}{the number of TSSs required at a given position for it to be considered in TSR identification. (numeric)}
+\item{tagCountThreshold}{the number of TSSs required at a given position
+for it to be considered in TSR identification. (numeric)}
 
-\item{clustDist}{the maximum distance of TSSs between two TSRs in base pairs. (numeric)}
+\item{clustDist}{the maximum distance of TSSs between two
+TSRs in base pairs. (numeric)}
 
-\item{writeTable}{specifies whether the output should be written to a table. (logical)}
+\item{writeTable}{specifies whether the output should
+be written to a table. (logical)}
 }
 \value{
-creates a list of \linkS4class{GenomicRanges}-containing TSR positions in slot \emph{@tsrData} on the \emph{tssObject} object
+creates a list of \linkS4class{GenomicRanges}-containing
+TSR positions in slot \emph{@tsrData} on the \emph{tssObject} object
 }
 \description{
-\code{determineTSR} Identifies TSRs from entire TSS datasets as specified.
+\code{determineTSR} Identifies TSRs from
+entire TSS datasets as specified.
 }
 \note{
-An example similar to this one can be found in \emph{Example 1} from the vignette (/inst/doc/TSRchitect.Rmd)
+An example similar to this one can be found in the vignette
+(/inst/doc/TSRchitect.Rmd)
 }
 \examples{
 load(system.file("extdata", "tssObjectExample.RData", package="TSRchitect"))
-determineTSR(experimentName=tssObjectExample, parallel=FALSE, tsrSetType="replicates", tssSet="1", tagCountThreshold=25, clustDist=20, writeTable=FALSE)
+determineTSR(experimentName=tssObjectExample, parallel=FALSE,
+tsrSetType="replicates", tssSet="1", tagCountThreshold=25,
+clustDist=20, writeTable=FALSE)
 
 }
 

--- a/man/importAnnotationHub.Rd
+++ b/man/importAnnotationHub.Rd
@@ -32,7 +32,7 @@ and attaches it to the \emph{tssObject}
 }
 \note{
 An example similar to the one provided can be found in
-\emph{Example 1} from the vignette (/inst/doc/TSRchitect.Rmd)
+the vignette (/inst/doc/TSRchitect.Rmd)
 
 Please consult the available records in AnnotationHub
 beforehand using \code{\link[AnnotationHub]{AnnotationHub}}

--- a/man/mergeSampleData.Rd
+++ b/man/mergeSampleData.Rd
@@ -20,7 +20,7 @@ experiments into a single \linkS4class{GRanges} object
 }
 \note{
 An example similar to the one provided can be found in
-\emph{Example 1} from the vignette (/inst/doc/TSRchitect.Rmd).
+the vignette (/inst/doc/TSRchitect.Rmd).
 }
 \examples{
 load(system.file("extdata", "tssObjectExample.RData",

--- a/man/processTSS.Rd
+++ b/man/processTSS.Rd
@@ -31,7 +31,7 @@ Note that the \emph{tssSet} parameter must be of class
 \emph{character}, even when selecting an individual dataset.
 
 An example similar to the one provided can be found in
-\emph{Example 1} from the vignette (/inst/doc/TSRchitect.Rmd).
+the vignette (/inst/doc/TSRchitect.Rmd).
 }
 \examples{
 load(system.file("extdata", "tssObjectExample.RData",

--- a/man/setSampleID.Rd
+++ b/man/setSampleID.Rd
@@ -11,10 +11,7 @@ setSampleID(experimentName, sample.names, replicate.IDs)
 contains information about the experiment.}
 
 \item{sample.names}{unique labels of class character for each TSS sample
-within the experiment.
-Please note that \code{importBam} attaches .bam data in ascending
-alphanumeric order, so \emph{sample.names} must be arranged in this order
-also so that they directly correspond to the intended file.}
+within the experiment.}
 
 \item{replicate.IDs}{identifiers indicating which samples are biological
 replicates. As with \emph{sample.names}, note that \code{importBam} imports
@@ -30,8 +27,10 @@ to your \emph{tssObject} object.
 for experimental samples in a \emph{tssObject} S4 object.
 }
 \note{
-An example similar to the one provided can be found in
-\emph{Example 1} from the vignette (/inst/doc/TSRchitect.Rmd)
+Please note that \code{importBam} attaches .bam data in ascending
+alphanumeric order, so \emph{sample.names} must be arranged in such
+a way that they directly correspond to the intended file.
+This order can be specified using \code{\link{getFileNames}}
 }
 \examples{
 load(system.file("extdata", "tssObjectExample.RData",


### PR DESCRIPTION
1. Removed specific references to Example 1 in vignette, which had been removed. 
2. fileNames length requirement in `setSampleID` as discussed. 
3. Split up long >80 character lines in `determineTSR`.