### PR TITLE
updates the get rid of assign to parent frame

### DIFF
--- a/R/addAnnotationToTSR.R
+++ b/R/addAnnotationToTSR.R
@@ -28,8 +28,7 @@
 #' to a tab-delimited file. Defaults to TRUE.
 #`
 #' @return addAnnotationToTSR adds feature annotation to the (merged)
-#' \emph{@@tsrData} data frame and returns the updated \emph{tssObject}
-#' to the workspace.
+#' \emph{@@tsrData} data frame and returns the updated \emph{tssObject}.
 #'
 #' @importFrom BiocGenerics start end
 #' @importFrom GenomicRanges GRanges findOverlaps promoters
@@ -176,10 +175,9 @@ setMethod("addAnnotationToTSR",
                   tsr.df -> experimentName@tsrDataMerged[[tsrSet]]
               }
 
-              cat("Done. GeneIDs have been associated with adjacent TSRs\n",
-                  "and the data frame has been re-assigned to its slot.\n")
+              cat("Done. GeneIDs have been associated with adjacent TSRs.\n")
               cat("---------------------------------------------------------\n")
-              assign(object.name, experimentName, envir = parent.frame())
               message(" Done.\n")
+              return( experimentName)
           }
           )

--- a/R/addTagCountsToTSR.R
+++ b/R/addTagCountsToTSR.R
@@ -15,7 +15,7 @@
 #'
 #' @return a matrix of tag counts (where the number of columns will equal
 #' the number of replicates in the sample) is appended to the data frame
-#' of the selected set of identified TSRs.
+#' of the selected set of identified TSRs in the returned \emph{tssObject}
 #'
 #' @importFrom utils write.table
 #'
@@ -176,7 +176,7 @@ setMethod("addTagCountsToTSR",
               }
 
               cat("---------------------------------------------------------\n")
-              assign(object.name, experimentName, envir = parent.frame())
               message(" Done.\n")
+              return(experimentName)
           }
           )

--- a/R/bamToTSS.R
+++ b/R/bamToTSS.R
@@ -6,7 +6,7 @@
 #'
 #' @return creates a list of TSSs in class \linkS4class{GRanges} for each
 #' .bam file contained within \emph{experimentName} and places them in
-#' the \emph{tssObject}.
+#' the returned \emph{tssObject}.
 #'
 #' @importFrom GenomicRanges granges GRanges GRangesList
 #' @importFrom BiocGenerics start end
@@ -81,7 +81,7 @@ setMethod("bamToTSS",
                   "have been successfully added to the \ntssObject \"",
                   object.name, "\".\n\n")
               cat("---------------------------------------------------------\n")
-              assign(object.name, experimentName, envir = parent.frame())
               message(" Done.\n")
+              return(experimentName)
           }
 )

--- a/R/clustering-functions.R
+++ b/R/clustering-functions.R
@@ -216,7 +216,7 @@ tsrCluster <- function(x, minNbrTSSs=3, minDist=20) {
          subset(sTSS, strand=="+") -> sTSS.p
          as.matrix(sTSS.p) -> sTSS.p
          nrow(sTSS.p) -> my.len
-         if (my.len == 0) { # ... assign an empty list to tss.list.p
+         if (my.len == 0) { # ... create an empty list tss.list.p
              vector(mode="list") -> tss.list.p
          }
          else if (my.len == 1) {
@@ -276,7 +276,7 @@ tsrCluster <- function(x, minNbrTSSs=3, minDist=20) {
          subset(sTSS, strand=="-") -> sTSS.m
          as.matrix(sTSS.m) -> sTSS.m
          nrow(sTSS.m) -> my.len
-         if (my.len == 0) { # ... assign an empty list to tss.list.m
+         if (my.len == 0) { # ... create an empty list tss.list.m
              vector(mode="list") -> tss.list.m
          }
          else if (my.len == 1) {

--- a/R/determineTSR.R
+++ b/R/determineTSR.R
@@ -20,7 +20,8 @@
 #' @importFrom BiocParallel bplapply MulticoreParam
 #'
 #' @return creates a list of \linkS4class{GenomicRanges}-containing
-#' TSR positions in slot \emph{@@tsrData} on the \emph{tssObject} object
+#' TSR positions in slot \emph{@@tsrData} of the returned \emph{tssObject}
+#' object
 #'
 #' @examples
 #' load(system.file("extdata", "tssObjectExample.RData", package="TSRchitect"))
@@ -175,7 +176,7 @@ setMethod("determineTSR",
                        "either \"replicates\" or \"merged\".")
               }
               cat("---------------------------------------------------------\n")
-              assign(object.name, experimentName, envir = parent.frame())
               message(" Done.\n")
+              return(experimentName)
           }
           )

--- a/R/importAnnotationExternal.R
+++ b/R/importAnnotationExternal.R
@@ -10,9 +10,9 @@
 #' @param annotFile - a path (full or relative) to the annotation
 #' file to be imported.
 #'
-#' @return fills the slot \emph{@@annotation} in the \emph{tssObject}
-#' with a \linkS4class{GRanges} object contining a parsed annotation
-#' file of the selected type.
+#' @return fills the slot \emph{@@annotation} in the returned
+#' \emph{tssObject} with a \linkS4class{GRanges} object contining a
+#' parsed annotation file of the selected type.
 #'
 #' @importFrom GenomicRanges GRanges
 #' @importFrom rtracklayer import.bed import.gff import.gff3
@@ -62,7 +62,7 @@ setMethod("importAnnotationExternal",
               cat("Done. Annotation data have been attached to",
                   "tssObject\nobject \"", object.name, "\".\n")
               cat("---------------------------------------------------------\n")
-              assign(object.name, experimentName, parent.frame())
               message(" Done.\n")
+              return(experimentName)
           }
           )

--- a/R/importAnnotationHub.R
+++ b/R/importAnnotationHub.R
@@ -12,7 +12,7 @@
 #' (e.g. 'human')
 #' @param annotID - 'character' the AnnotationHub identifier to be retrieved
 #'
-#' @return fills the slot \emph{@@annotation} in the \emph{tssObject}
+#' @return fills the slot \emph{@@annotation} in the returned \emph{tssObject}
 #' with an AnnotationHub record. The record retrieved must be an object
 #' of class \linkS4class{GRanges}.
 #'
@@ -54,7 +54,7 @@ setMethod("importAnnotationHub",
               cat("Done. Annotation data have been attached to",
                   "tssObject\nobject \"", object.name, "\".\n")
               cat("---------------------------------------------------------\n")
-              assign(object.name, experimentName, parent.frame())
               message(" Done.\n")
+              return(experimentName)
           }
           )

--- a/R/importBam.R
+++ b/R/importBam.R
@@ -9,7 +9,7 @@
 #' Note that all the paths to all files in \emph{expDir} with the extension
 #' .bam in \emph{expDir} will be imported with this function.
 #'
-#' @return \emph{importBam} fills the slot \emph{bamData} on the
+#' @return \emph{importBam} fills the slot \emph{bamData} on the returned
 #' \emph{tssObject} with \linkS4class{GAlignments} objects from the
 #' \bold{GenomicAlignments} package, one for each attached .bam file
 #' on the \emph{fileNames} slot.
@@ -89,7 +89,7 @@ setMethod("importBam",
                   " bam files have been attached to tssObject\nobject \"",
                   object.name, "\".\n")
               cat("---------------------------------------------------------\n")
-              assign(object.name, experimentName, parent.frame())
               message(" Done.\n")
+              return(experimentName)
           }
           )

--- a/R/initializeExp.R
+++ b/R/initializeExp.R
@@ -10,8 +10,7 @@
 #' @param isPairedEnd specifies whether the TSS profiling experiment is
 #' paired-end (if TRUE) or single-end (if FALSE) (logical)
 #'
-#' @return Creates a new \emph{tssObject} with the name \emph{experimentName}
-#' that is written to the user's working environment.
+#' @return a new \emph{tssObject} with name \emph{experimentName}
 #'
 #' @importFrom methods new
 #'
@@ -42,7 +41,7 @@ setMethod("initializeExp",
               cat("\nThe tssObject object \"", experimentName,
                   "\" has been initialized in your workspace.\n")
               cat("---------------------------------------------------------\n")
-              assign(experimentName, tssObj, parent.frame())
               message(" Done.\n")
+              return(tssObj)
           }
           )

--- a/R/mergeSampleData.R
+++ b/R/mergeSampleData.R
@@ -5,8 +5,9 @@
 #' @param experimentName an S4 object of class \emph{tssObject} that contains
 #' information about the experiment.
 #'
-#' @return tssCountData datasets will be merged (according to the
-#' \emph{sampleIDs}) and assigned to your \emph{tssObject}.
+#' @return tssCountData datasets are merged (according to the
+#' \emph{sampleIDs}) and put in the tssCountDataMerged slot in the returned
+#' \emph{tssObject}.
 #'
 #' @importFrom GenomicRanges as.data.frame
 #' @importFrom gtools mixedorder
@@ -85,7 +86,7 @@ setMethod("mergeSampleData",
               cat("\n... the TSS expression data have been successfully merged",
                     "and added to\ntssObject object \"", object.name, "\"\n")
               cat("---------------------------------------------------------\n")
-              assign(object.name, experimentName, envir = parent.frame())
               message(" Done.\n")
+              return(experimentName)
           }
           )

--- a/R/processTSS.R
+++ b/R/processTSS.R
@@ -14,7 +14,7 @@
 #' @importFrom BiocParallel bplapply MulticoreParam
 #'
 #' @return Creates a list of \linkS4class{GenomicRanges} containing TSS
-#' positions in slot \emph{tssTagData} on the \emph{tssObject}.
+#' positions in slot \emph{tssTagData} of the returned \emph{tssObject}.
 #'
 #' @examples
 #' load(system.file("extdata", "tssObjectExample.RData",
@@ -46,24 +46,25 @@ setMethod("processTSS",
                   iend <- length(experimentName@tssTagData)
                   if (n.cores > 1) {
                       multicoreParam <- MulticoreParam(workers=n.cores)
-                      FUN  <- function(x) {
-                             prcTSS(experimentName, tssSet=x,
-                             writeTable=writeTable)
+                      FUN <- function(x) {
+                                prcTSS(experimentName, tssSet=x,
+                                       writeTable=writeTable)
                              }
                       experimentName@tssCountData <- bplapply(1:iend, FUN)
                       }
                   else {
-                     for (i in 1:iend) {
-  experimentName@tssCountData[[i]] <- prcTSS(experimentName=experimentName,
-                                            tssSet = i, writeTable=TRUE)
+                      for (i in 1:iend) {
+                          experimentName@tssCountData[[i]] <-
+                            prcTSS(experimentName=experimentName, tssSet = i,
+                                   writeTable=TRUE)
                       }
                  }
               }
               else {
                   i <- as.numeric(tssSet)
-                  if (i > length(experimentName@tssCountData)) {
+                  if (i > length(experimentName@tssTagData)) {
                       stop("The value selected for tssSet exceeds",
-                           "the number of slots in tssCountData.")
+                           "the number of slots in tssTagData.")
                   }
                   experimentName@tssCountData[[i]] <- prcTSS(experimentName =
                                                              experimentName,
@@ -71,7 +72,7 @@ setMethod("processTSS",
                                                              writeTable)
               }
               cat("---------------------------------------------------------\n")
-              assign(object.name, experimentName, envir = parent.frame())
               message(" Done.\n")
+              return(experimentName)
           }
           )

--- a/R/setSampleID.R
+++ b/R/setSampleID.R
@@ -11,8 +11,8 @@
 #' bam data in ascending alphanumeric order, so replicate.IDs must be arranged
 #' in this order also so that they directly correspond to the intended file.
 #'
-#' @return names and replicate information for experimental samples assigned
-#' to your \emph{tssObject} object.
+#' @return names and replicate information for experimental samples added
+#' to the returned \emph{tssObject} object.
 #'
 #' @examples
 #' load(system.file("extdata", "tssObjectExample.RData",
@@ -61,11 +61,11 @@ setMethod("setSampleID",
               rep.list <- vector(mode="list", length=exp.len)
               experimentName@tsrData <- rep.list
 
-              cat("\nNames and replicate IDs were successfully assigned",
+              cat("\nNames and replicate IDs were successfully added",
                   "to tssObject\nobject \"", object.name, "\".\n\n")
 
               cat("---------------------------------------------------------\n")
-              assign(object.name, experimentName, parent.frame())
               message(" Done.\n")
+              return(experimentName)
           }
           )


### PR DESCRIPTION
This code update is the first implementation with "return" instead of "assign to parent frame".
Checked on the the demo AtPEAT example; see updated AtPEAT.Rscript.
Other demo examples have not been updated.

To do: initializeExp should be combined with importBam and setSampleID; see methRead in methylKit for an example.  The function could be "setupTSR" and be invoked as

AtPEAT <- setupTSR( arguments )

where arguments are the the relevant arguments from importBam and setSampleID.