### PR TITLE
Corrections to vignette and tsrToDF()

### DIFF
--- a/R/addAnnotationToTSR.R
+++ b/R/addAnnotationToTSR.R
@@ -76,6 +76,8 @@ setMethod("addAnnotationToTSR",
                           " has been written to file ", outfname,
                           "\nin your working directory.")
                   tsr.df <- experimentName@tsrData[[tsrSet]]
+                  tsr.df$start <- as.numeric(as.character(tsr.df$start))
+                  tsr.df$end <- as.numeric(as.character(tsr.df$end))
               }
               else if (tsrSetType=="merged") {
                   if (length(experimentName@tsrDataMerged)<1) {
@@ -100,6 +102,8 @@ setMethod("addAnnotationToTSR",
                               "\nin your working directory.")
                   }
                   tsr.df <- experimentName@tsrDataMerged[[tsrSet]]
+                  tsr.df$start <- as.numeric(as.character(tsr.df$start))
+                  tsr.df$end <- as.numeric(as.character(tsr.df$end))
               }
               else {
                   stop("Error: argument tsrSetType to addAnnotationToTSR()",

--- a/R/addTagCountsToTSR.R
+++ b/R/addTagCountsToTSR.R
@@ -128,14 +128,14 @@ setMethod("addTagCountsToTSR",
 #  ... otherwise, we see how a given sample TSS position fits
 #  into the current TSRs:
                             if (this.tsr$strand == this.tss$strand) {
-                               if (this.tsr$start  <= this.tss$TSS   &&
-                                   this.tss$TSS <= this.tsr$end) {
+                               if (as.numeric(this.tsr$start)  <= this.tss$TSS   &&
+                                   this.tss$TSS <= as.numeric(this.tsr$end)) {
                                   count <- count + this.tss$nTSSs
                                   if (l == nrow(that.tssSet)) {
                                       countv[k] <- count
                                   }
                                }
-                               else if (this.tss$TSS  > this.tsr$start) {
+                               else if (this.tss$TSS  > as.numeric(this.tsr$start)) {
                                   countv[k] <- count
                                   lbeg <- l
                                   count <- 0

--- a/R/tsrToDF.R
+++ b/R/tsrToDF.R
@@ -19,71 +19,60 @@
 #'         \item shapeIndex = shape index value of TSR (num)
 #' }
 
+tsrToDF <- function(clstOut) {
+    
+                    df.fun.p <- function(chrLst) {
+                          my.string <- lapply(chrLst, countsToVector)
+                          my.SI <- sapply(my.string, shapeIndex)
+                          my.SI <- round(my.SI, digits=2)
+                          my.vec <- lapply(chrLst, "[", 1, )
+                          my.range <- lapply(my.vec, range)
+                          my.width <- lapply(my.range, function(x) (x[2]-x[1])+1)
+                          my.width <- do.call(rbind, my.width)
+                          my.start <- vapply(my.range, min, numeric(1))
+                          my.end <- vapply(my.range, max, numeric(1))
+                          my.counts <- vapply(chrLst, tsrCounts, numeric(1))
+                          my.strand <- rep("+", length(my.vec))
+                          string.out.p <- cbind(my.start, my.end, my.strand, my.counts, my.width, my.SI)
+                          return(string.out.p)
+                      }
 
-tsrToDF <- function(x) {
-    len.list <- length(x)
-    seq.vec <- names(x)
-    final.matrix <- matrix(NA, nrow=1, ncol=7)
+                     df.fun.m <- function(chrLst) {
+                          my.string <- lapply(chrLst, countsToVector)
+                          my.SI <- sapply(my.string, shapeIndex)
+                          my.SI <- round(my.SI, digits=2)
+                          my.vec <- lapply(chrLst, "[", 1, )
+                          my.range <- lapply(my.vec, range)
+                          my.width <- lapply(my.range, function(x) (x[2]-x[1])+1)
+                          my.width <- do.call(rbind, my.width)
+                          my.start <- vapply(my.range, min, numeric(1))
+                          my.end <- vapply(my.range, max, numeric(1))
+                          my.counts <- vapply(chrLst, tsrCounts, numeric(1))
+                          my.strand <- rep("-", length(my.vec))
+                          string.out.m <- cbind(my.start, my.end, my.strand, my.counts, my.width, my.SI)
+                          return(string.out.m)
+                      }
 
-     for (j in 1:len.list) { ## replace this loop with do.call(rbind,) #make sure you look at the imput of tsrCluster
-         my.list.p <- vector(mode="list", length=2)
-         my.list.m <- vector(mode="list", length=2)
-         this.seq <- as.character(seq.vec[j])
-         this.seq.list <- x[[j]]
-
-          this.p <- this.seq.list$plus
-         my.strand <- c("+")
-         plus.matrix <- matrix(NA, nrow=length(this.p), ncol=7) #rather than matrix, compute the columns in vectorized fashion
-        if (length(this.p) > 0 ) { # ensures there are + strand TSRs to process
-           for (i in 1:max(1,length(this.p))) { #this is probaly vectorizable using vapply() #this data 
-               my.tsr <- this.p[[i]] 
-               my.vec <- countsToVector(my.tsr)
-               my.SI <- shapeIndex(my.vec)
-               my.SI <- round(my.SI, digits=2)
-               my.counts <- tsrCounts(my.tsr)
-               my.width <- tsrWidth(my.tsr)
-               my.range <- range(my.vec)
-               my.start <- my.range[1]
-               my.end <- my.range[2]
-               my.string <- c(this.seq, my.start, my.end, my.strand, my.counts,
-                              my.width, my.SI)
-               plus.matrix[i,] <- my.string
-           }
-        }
-
-        this.m <- this.seq.list$minus
-        my.strand <- c("-")
-        minus.matrix <- matrix(NA, nrow=length(this.m), ncol=7)
-        if (length(this.m) > 0 ) { # ensures there are - strand TSRs to process
-           for (i in 1:max(1,length(this.m))){
-               my.tsr <- this.m[[i]]
-               my.vec <- countsToVector(my.tsr)
-               my.SI <- shapeIndex(my.vec)
-               my.SI <- round(my.SI, digits=2)
-               my.counts <- tsrCounts(my.tsr)
-               my.width <- tsrWidth(my.tsr)
-               my.range <- range(my.vec)
-               my.start <- my.range[1]
-               my.end <- my.range[2]
-               my.string <- c(this.seq, my.start, my.end, my.strand, my.counts,
-                 my.width, my.SI)
-               minus.matrix[i,] <- my.string
-           }
-        }
-
-        seq.matrix <- rbind(plus.matrix, minus.matrix)
-        final.matrix <- rbind(final.matrix, seq.matrix)
-    }
-    final.matrix <- final.matrix[-1,] #removes the 1st row used to initialize
-    colnames(final.matrix) <- c("seq", "start", "end", "strand",
-                                "nTSSs", "tsrWidth", "shapeIndex")
-    final.df <- as.data.frame(final.matrix)
-    #Convert dataframe column classes to appropriate types:
-    final.df$seq   <- as.character(final.df$seq)
-    final.df$start <- as.numeric(as.character(final.df$start))
-    final.df$end   <- as.numeric(as.character(final.df$end))
-    final.df$nTSSs <- as.numeric(as.character(final.df$nTSSs))
-    final.df$tsrWidth   <- as.numeric(as.character(final.df$tsrWidth))
-    final.df$shapeIndex   <- as.numeric(as.character(final.df$shapeIndex))
-    return(final.df)
+                    chrToDF  <- function(x) {
+                        my.list <- vector(mode="list")
+                        list.p <- x$plus
+                        list.m <- x$minus
+                        my.list$plus <- df.fun.p(list.p)
+                        my.list$minus <- df.fun.m(list.m)
+                        my.out <- do.call(rbind, my.list)
+                        return(my.out)
+                    }
+                    
+    options(warn=-1)
+    names.list <- lapply(clstOut, function(x) sapply(x, length))
+    my.sum <- lapply(names.list, sum)
+    seq <- as.data.frame(rep(names(my.sum), my.sum))
+    this.list <- lapply(clstOut, chrToDF)
+    my.df <- do.call(rbind, this.list)
+    my.df <- as.data.frame(my.df)
+    my.df <- data.frame(seq, my.df)
+    colnames(my.df) <- c("seq", "start","end", "strand", "nTSSs", "tsrWidth", "shapeIndex")
+    return(my.df)
 }
+
+

--- a/R/writeTSR.R
+++ b/R/writeTSR.R
@@ -119,12 +119,14 @@ setMethod("writeTSR",
               }
               else {
                   tsr.df$ID <- paste(tsr.df$seq, tsr.df$start, tsr.df$end,
-                               tsr.df$strand, sep=".")
+                                     tsr.df$strand, sep=".")
                   bed.df <- tsr.df[, c("seq", "start", "end", "ID",
                              "shapeIndex", "strand")]
                   colnames(bed.df) <- c("chrom", "start", "end",
                                       "name", "score", "strand")
-                  bed.df$start <- bed.df$start
+                  bed.df$start <- as.numeric(as.character(bed.df$start))
+                  bed.df$end  <- as.numeric(as.character(bed.df$end))
+                  my.score <- as.numeric(as.character(bed.df$score))
                   bed.gr <- makeGRangesFromDataFrame(bed.df,
                                            keep.extra.columns=TRUE,
                                            ignore.strand=FALSE,

--- a/vignettes/TSRchitect.Rmd
+++ b/vignettes/TSRchitect.Rmd
@@ -35,8 +35,8 @@ TSRchitectUsersGuide()
 
 Now that you have loaded TSRchitect, we can proceed with a small example.
 
-First, we will create a tssObject and import our sample bam files (which are found in `extdata/`).
-In doing this, we provide sample names and identify our replicate names using `setSampleID`.
+First, we will create a tssObject using `loadTSSobj` and import our sample bam files (which are found in `extdata/`).
+In doing this, we provide sample names and identify our replicate names using the argument `sampleNames`.
 We do this in the following manner:
 
 ```{r eval=TRUE}
@@ -73,7 +73,7 @@ tsrSetType="replicates", tssSet="all", tagCountThreshold=25, clustDist=20,
 writeTable=FALSE)
 ```
 
-Next we merge our replicate data (according to the information we provided in `setSampleID`) and identify TSRs on these merged samples. We then use `addTagCountsToTSR` to quantify the number of tags found in each of our 4 datasets.
+Next we merge our replicate data (according to the information we provided in `loadTSSobj`) and identify TSRs on these merged samples. We then use `addTagCountsToTSR` to quantify the number of tags found in each of our 4 datasets.
 
 ```{r eval=TRUE}
 tssObjectExample <- mergeSampleData(experimentName=tssObjectExample)


### PR DESCRIPTION
Loops in `tsrToDF()` was refactored using `lapply`, `vapply`, `sapply` and `do.call(rbind, ...)` as requested by BioC review.
References to deprecated code in the vignette were removed.