### PR TITLE
Corrected typo in documentation of createSummarizedExperiment()

### DIFF
--- a/R/createSummarizedExperiment.R
+++ b/R/createSummarizedExperiment.R
@@ -22,7 +22,7 @@
 #'
 #' @examples
 #' load(system.file("extdata", "tssObjectExample.RData", package="TSRchitect"))
-#' createSumarizedExperiment(tssObjectExample, tsrSetType="merged", tsrSet=1,
+#' createSummarizedExperiment(tssObjectExample, tsrSetType="merged", tsrSet=1,
 #' samplePrefix=c("sample1","sample2"))
 #'
 #' @note For more information on the SummarizedExperiment class, please visit

--- a/man/createSummarizedExperiment.Rd
+++ b/man/createSummarizedExperiment.Rd
@@ -35,7 +35,7 @@ https://bioconductor.org/packages/release/bioc/vignettes/SummarizedExperiment/in
 }
 \examples{
 load(system.file("extdata", "tssObjectExample.RData", package="TSRchitect"))
-createSumarizedExperiment(tssObjectExample, tsrSetType="merged", tsrSet=1,
+createSummarizedExperiment(tssObjectExample, tsrSetType="merged", tsrSet=1,
 samplePrefix=c("sample1","sample2"))
 
 }


### PR DESCRIPTION
Typo prevented example from running correctly. Thanks @vpbrendel for the catch.