### PR TITLE
fix for incorrect implementation of getFileNames()

### DIFF
--- a/R/Get-methods.R
+++ b/R/Get-methods.R
@@ -67,11 +67,11 @@ setMethod("getFileNames",
 signature(experimentName = "tssObject"),
 function (experimentName){
         my.files <- vector(mode="character")
-    if (exists(experimentName@fileNamesBAM[[1]])) {
+    if (length(experimentName@fileNamesBAM) > 0) {
         my.files1 <- experimentName@fileNamesBAM
         my.files <- c(my.files, my.files1)
     }
-    if (exists(experimentName@fileNamesBED[[1]])) {
+    if (length(experimentName@fileNamesBED) > 0) {
         my.files1 <- experimentName@fileNamesBED
         my.files <- c(my.files, my.files1)
     }


### PR DESCRIPTION
Example 1 in our TSRchitectUsersGuide showed that exists() does not work as we had it.