### PR TITLE
Minor formatting update to NEWS section

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,18 +1,20 @@
 0.1.0 (01-09-2017)
-Code has been tested and is stable. Preparing for submission to Bioconductor once vignette (and various other requirements) is complete.
++ Code has been tested and is stable. Preparing for submission to Bioconductor once vignette (and various other requirements) is complete.
 0.2.0 (01-18-2017)
-Vignette completed testing
++ Vignette completed testing
 0.99.0 (01-20-2017)
-Package (version 0.99.0) submitted to Bioconductor for review
++ Package (version 0.99.0) submitted to Bioconductor for review
 0.99.2 (02-24-2017)
-Revised package (version 0.99.2) submitted to Bioconductor for further review
++ Revised package (version 0.99.2) submitted to Bioconductor for further review
 0.99.2 (04-18-2017)
-Revised package (version 0.99.2) submitted to Bioconductor for review
++ Revised package (version 0.99.2) submitted to Bioconductor for review
 1.0.0 (04-19-2017)
-Package accepted (version 1.0.0) at Bioconductor, included in version 3.5.
++ Package accepted (version 1.0.0) at Bioconductor, included in version 3.5.
 1.2.0 (09-26-2017) 
-Support added for the analysis of ESTs/cDNAs; BED files can now be provided as input (version 1.2.0)
++ Support added for the analysis of ESTs/cDNAs; BED files can now be provided as input (version 1.2.0)
 1.2.1 (10-17-2017)
-Minor changes in documentation to better reflect updates in v. 1.2 (version 1.2.1).
++ Minor changes in documentation to better reflect updates in v. 1.2 (version 1.2.1).
 1.8.0 (07-10-2018)
-Additional promoter (TSR) metrics added to output, including the modified shape index (mSI) and torque. Modifications to column IDs to reflect updated nomenclature (version 1.7.0). Updates to User's Guide in addition to creation of Singularity recipe for reproucible analysis across platforms.
++ Additional promoter (TSR) metrics added to output, including the modified shape index (mSI) and torque.
++ Modifications to column IDs to reflect updated nomenclature.
++ Updates to User's Guide in addition to creation of Singularity recipe for reproucible analysis across platforms.


### PR DESCRIPTION
- This had been requested by Lori Shepard from Bioconductor; I complied, but ignored the "+" characters. This has been corrected (and submitted)