### PR TITLE
Updated NEWS to reflect latest changes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: TSRchitect
-Version: 2.0.0
-Date: 2018-10-07
+Version: 1.8.9
+Date: 2018-10-08
 Title: Promoter identification from large-scale TSS profiling data
 Description: In recent years, large-scale transcriptional sequence data has
     yielded considerable insights into the nature of gene expression and regulation

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,34 +1,36 @@
 # __TSRchitect__ Installation and Setup
 
 ## Preliminary Steps
-__TSRchitect__ is a package for the [R software environment for statistical
+__TSRchitect__ is package for the [R software environment for statistical
 computing](https://www.r-project.org/).
-We assume that you have a current version of [R](https://www.r-project.org/)
+We assume that you have a current version of [R](https://www.r-project.org/)s
  installed and are familiar with its use.
 Several other packages are prerequisite for __TSRchitect__, and these packages
-are available through
-[CRAN](https://cran.r-project.org/) or
-[Bioconductor](http://bioconductor.org/).
-Typical preliminary steps to install or update these packages are as follows
+are available through [_Bioconductor_](http://bioconductor.org/).
+We assume that you have a current version of [R](https://www.r-project.org/)
+installed and are familiar with its use.
+Typical preliminary steps to install or updated these packages are as follows
 (note: for system-wide installation, you would need to invoke
 [R](https://www.r-project.org/) as root):
 
 ```{r eval=FALSE}
 #installing CRAN packages
 install.packages(c("gtools","knitr"))
+```
 
-#installing Bioconductor packages
-source("http://bioconductor.org/biocLite.R")
-biocLite(c("AnnotationHub", "BiocGenerics", "BiocParallel",
-"ENCODExplorer", "GenomicAlignments", "GenomeInfoDb",
-"GenomicRanges", "IRanges", "Rsamtools", "rtracklayer",
-"S4Vectors", "SummarizedExperiment"))
+```{r eval=FALSE}
+if (!requireNamespace("BiocManager", quietly=TRUE))
+    install.packages("BiocManager")
+BiocManager::install(c("AnnotationHub", "BiocGenerics", "BiocParallel",
+"ENCODExplorer", "GenomicAlignments", "GenomeInfoDb", "GenomicRanges",
+"IRanges", "Rsamtools", "rtracklayer", "S4Vectors", "SummarizedExperiment"))
 ```
 
 ## Obtaining TSRchitect
 __TSRchitect__ is available as a
-[Bioconductor](http://bioconductor.org/) package and thus can be installed in
-the same way as the prerequisite packages:
+[_Bioconductor_](http://bioconductor.org/) package.
+
+Once the prerequisites have been installed, _TSRchitect_ can be installed directly from [_Bioconductor_] as follows:
 
 ```{r eval=FALSE}
 if (!requireNamespace("BiocManager", quietly=TRUE))
@@ -36,46 +38,34 @@ if (!requireNamespace("BiocManager", quietly=TRUE))
 BiocManager::install("TSRchitect")
 ```
 
-Optionally, you can install __TSRchitect__ directly from our group's GitHub
-repository as follows (again, use root privileges on the install command for
-system-wide installation):
+Optionally (and in general, for the latest development version), you can install
+__TSRchitect__ directly from our group's GitHub repository as follows (again,
+use root privileges on the install command for system-wide installation):
 
+This repository contains two branches. The branch 'master' is our stable, submitted Bioconductor version, whereas our 'devel' branch contains recent development and additional files that are not found in the branch master.
+
+If you wish to clone and install the current stable version of the software, please type the following command:
 ```{bash eval=FALSE}
 git clone https://github.com/BrendelGroup/TSRchitect
 R CMD INSTALL TSRchitect
 ```
 
-Note that the `master` branch should be a stable version, possibly somewhat
-ahead of the Biocondcutor version in case of minor edits or addtions.
-You may also see a `devel` branch, which would contain recently developed
-addtions that are not yet fully tested.
 To clone and install just the 'devel' branch, please do the following:
 ```{bash eval=FALSE}
 git clone https://github.com/BrendelGroup/TSRchitect --branch devel --single-branch
 R CMD INSTALL TSRchitect
 ```
-In either case, please use the _GitHub Issues_ button to report problems or
-suggest novel features.
 
+To check on successful installation, load the package in your
+R console:
 
-## Installation as a singularity container
-
-Assuming a current version of _singularity_ is installed on your system (if not,
-it should be, and it's easy to do so), you can get the TSRchitect container from
-[Singularity Hub](https://www.singularity-hub.org/collections/1204) as follows:
-
-```bash
-singularity pull --name tsr.simg shub://BrendelGroup/TSRchitect
+```{r eval=FALSE}
+library(TSRchitect)
 ```
-
-For a gentle introduction to singularity, see our group
-[handbook article](https://github.com/BrendelGroup/bghandbook/blob/master/doc/06.2-Howto-Singularity-run.md).
-
+Either fix problems according to displayed error messages, or go on to the next
+step.
 
 ## Finally
 
-Proceed to the [TSRchitectUsersGuide](./inst/doc/TSRchitectUsersGuide.Rmd) for
-examples of how the use TSRchitect functions.
-If you are interested in developing and running entire workflows for
-transcription start site profiling, please see our paper or simple worked
-examples in the [HOWTO](./demo/HOWTO.md) document.
+Proceed to the vignette (inst/doc/TSRchitect.md), and we'll tell you how to execute
+sample workflows (or, equally easy, your very own data analyses).

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,7 +19,10 @@ install.packages(c("gtools","knitr"))
 
 #installing Bioconductor packages
 source("http://bioconductor.org/biocLite.R")
-biocLite(c("AnnotationHub", "BiocGenerics", "BiocParallel", "ENCODExplorer", "GenomicAlignments", "GenomeInfoDb", "GenomicRanges", "IRanges", "methods", "Rsamtools", "rtracklayer", "S4Vectors", "SummarizedExperiment"))
+biocLite(c("AnnotationHub", "BiocGenerics", "BiocParallel",
+"ENCODExplorer", "GenomicAlignments", "GenomeInfoDb",
+"GenomicRanges", "IRanges", "Rsamtools", "rtracklayer",
+"S4Vectors", "SummarizedExperiment"))
 ```
 
 ## Obtaining TSRchitect
@@ -28,8 +31,9 @@ __TSRchitect__ is available as a
 the same way as the prerequisite packages:
 
 ```{r eval=FALSE}
-source("http://bioconductor.org/biocLite.R")
-biocLite("TSRchitect")
+if (!requireNamespace("BiocManager", quietly=TRUE))
+    install.packages("BiocManager")
+BiocManager::install("TSRchitect")
 ```
 
 Optionally, you can install __TSRchitect__ directly from our group's GitHub

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,36 +1,36 @@
 # __TSRchitect__ Installation and Setup
 
 ## Preliminary Steps
-__TSRchitect__ is package for the [R software environment for statistical
+__TSRchitect__ is a package for the [R software environment for statistical
 computing](https://www.r-project.org/).
-We assume that you have a current version of [R](https://www.r-project.org/)s
+We assume that you have a current version of [R](https://www.r-project.org/)
  installed and are familiar with its use.
 Several other packages are prerequisite for __TSRchitect__, and these packages
-are available through [_Bioconductor_](http://bioconductor.org/).
-We assume that you have a current version of [R](https://www.r-project.org/)
-installed and are familiar with its use.
-Typical preliminary steps to install or updated these packages are as follows
+are available through
+[CRAN](https://cran.r-project.org/) or
+[Bioconductor](http://bioconductor.org/).
+Typical preliminary steps to install or update these packages are as follows
 (note: for system-wide installation, you would need to invoke
 [R](https://www.r-project.org/) as root):
 
 ```{r eval=FALSE}
 #installing CRAN packages
 install.packages(c("gtools","knitr"))
-```
 
-```{r eval=FALSE}
+```{r eval=FALSE}                              
 if (!requireNamespace("BiocManager", quietly=TRUE))
-    install.packages("BiocManager")
+   install.packages("BiocManager")
+#installing Bioconductor packages
 BiocManager::install(c("AnnotationHub", "BiocGenerics", "BiocParallel",
-"ENCODExplorer", "GenomicAlignments", "GenomeInfoDb", "GenomicRanges",
-"IRanges", "Rsamtools", "rtracklayer", "S4Vectors", "SummarizedExperiment"))
+"ENCODExplorer", "GenomicAlignments", "GenomeInfoDb",
+"GenomicRanges", "IRanges", "Rsamtools", "rtracklayer",
+"S4Vectors", "SummarizedExperiment"))
 ```
 
 ## Obtaining TSRchitect
 __TSRchitect__ is available as a
-[_Bioconductor_](http://bioconductor.org/) package.
-
-Once the prerequisites have been installed, _TSRchitect_ can be installed directly from [_Bioconductor_] as follows:
+[Bioconductor](http://bioconductor.org/) package and thus can be installed in
+the same way as the prerequisite packages:
 
 ```{r eval=FALSE}
 if (!requireNamespace("BiocManager", quietly=TRUE))
@@ -38,34 +38,46 @@ if (!requireNamespace("BiocManager", quietly=TRUE))
 BiocManager::install("TSRchitect")
 ```
 
-Optionally (and in general, for the latest development version), you can install
-__TSRchitect__ directly from our group's GitHub repository as follows (again,
-use root privileges on the install command for system-wide installation):
+Optionally, you can install __TSRchitect__ directly from our group's GitHub
+repository as follows (again, use root privileges on the install command for
+system-wide installation):
 
-This repository contains two branches. The branch 'master' is our stable, submitted Bioconductor version, whereas our 'devel' branch contains recent development and additional files that are not found in the branch master.
-
-If you wish to clone and install the current stable version of the software, please type the following command:
 ```{bash eval=FALSE}
 git clone https://github.com/BrendelGroup/TSRchitect
 R CMD INSTALL TSRchitect
 ```
 
+Note that the `master` branch should be a stable version, possibly somewhat
+ahead of the Biocondcutor version in case of minor edits or addtions.
+You may also see a `devel` branch, which would contain recently developed
+addtions that are not yet fully tested.
 To clone and install just the 'devel' branch, please do the following:
 ```{bash eval=FALSE}
 git clone https://github.com/BrendelGroup/TSRchitect --branch devel --single-branch
 R CMD INSTALL TSRchitect
 ```
+In either case, please use the _GitHub Issues_ button to report problems or
+suggest novel features.
 
-To check on successful installation, load the package in your
-R console:
 
-```{r eval=FALSE}
-library(TSRchitect)
+## Installation as a singularity container
+
+Assuming a current version of _singularity_ is installed on your system (if not,
+it should be, and it's easy to do so), you can get the TSRchitect container from
+[Singularity Hub](https://www.singularity-hub.org/collections/1204) as follows:
+
+```bash
+singularity pull --name tsr.simg shub://BrendelGroup/TSRchitect
 ```
-Either fix problems according to displayed error messages, or go on to the next
-step.
+
+For a gentle introduction to singularity, see our group
+[handbook article](https://github.com/BrendelGroup/bghandbook/blob/master/doc/06.2-Howto-Singularity-run.md).
+
 
 ## Finally
 
-Proceed to the vignette (inst/doc/TSRchitect.md), and we'll tell you how to execute
-sample workflows (or, equally easy, your very own data analyses).
+Proceed to the [TSRchitectUsersGuide](./inst/doc/TSRchitectUsersGuide.Rmd) for
+examples of how the use TSRchitect functions.
+If you are interested in developing and running entire workflows for
+transcription start site profiling, please see our paper or simple worked
+examples in the [HOWTO](./demo/HOWTO.md) document.

--- a/NEWS
+++ b/NEWS
@@ -18,3 +18,6 @@
 + Additional promoter (TSR) metrics added to output, including the modified shape index (mSI) and torque.
 + Modifications to column IDs to reflect updated nomenclature.
 + Updates to User's Guide in addition to creation of Singularity recipe for reproucible analysis across platforms.
+1.8.9 (10-08-2018)
++ Updates that correct a speed issue encountered when analyzing data aligned to assemblies with many scaffolds.
++ Simplified part of one vignette.

--- a/inst/doc/TSRchitectUsersGuide.Rmd
+++ b/inst/doc/TSRchitectUsersGuide.Rmd
@@ -172,8 +172,9 @@ Now that identifying TSRs are complete, an obvious and biologically useful step 
 Please install `AnnotationHub` if you haven't already done so.
 
 ```{r eval=FALSE}
-source("https://bioconductor.org/biocLite.R") 
-biocLite("AnnotationHub")
+if (!requireNamespace("BiocManager", quietly=TRUE))
+    install.packages("BiocManager")
+BiocManager::install("AnnotationHub")
 ```
 
 In our case we need to download the [Gencode](https://www.gencodegenes.org/) annotation.


### PR DESCRIPTION
- also reverted `TSRchitect` version to 1.8.9 to reflect BioC policies on version numbering [https://bioconductor.org/developers/how-to/version-numbering/](url) 
- replaced instances of `biocLite()` with `BiocManager()` as per (recently adopted) Bioconductor policy ([https://cran.r-project.org/web/packages/BiocManager/vignettes/BiocManager.html](url))
- all recent updates should now be ready for submission to Bioconductor github branch