### PR TITLE
corrected use of writeTSR in other functions; use of tssSetType varia…

### DIFF
--- a/R/Show-methods.R
+++ b/R/Show-methods.R
@@ -15,7 +15,7 @@ setMethod("show",
               }
               if (length(is.na(object@fileNamesBAM))>0) {
                   cat("There are ", length(object@fileNamesBAM))
-                  cat(".bam datasets loaded, as follows:\n")
+                  cat(" .bam datasets loaded, as follows:\n")
                   for (i in 1:length(object@fileNamesBAM)) {
                       cat(paste(object@fileNamesBAM[i]), sep="\n")
                   }
@@ -26,7 +26,7 @@ setMethod("show",
               }
               if (length(is.na(object@fileNamesBED))>0) {
                   cat("There are ", length(object@fileNamesBED))
-                  cat(".bed datasets loaded, as follows:\n")
+                  cat(" .bed datasets loaded, as follows:\n")
                   for (i in 1:length(object@fileNamesBED)) {
                       cat(paste(object@fileNamesBED[i]), sep="\n")
                   }

--- a/R/addTagCountsToTSR.R
+++ b/R/addTagCountsToTSR.R
@@ -8,15 +8,17 @@
 #' Options are "replicates" or "merged". (character)
 #' @param tsrSet number of the dataset to be processed, where 1 corresponds
 #' to the first slot, and so on. (numeric)
-#' @param tagCountThreshold number of TSSs required at a given position
-#' (numeric)
+#' @param tagCountThreshold number of tags required at a given TSS position in
+#' order to be included in the overall count for a TSR (numeric)
 #' @param writeTable specifies whether the output should be written to
 #' a table. (logical)
 #'
-#' @return a matrix of tag counts (where the number of columns will equal
-#' the number of replicates in the sample) is appended to the data frame
-#' of the selected set of identified TSRs in the returned \emph{tssObject}
+#' @return a matrix of tag counts and median-normalized tag counts is appended
+#' to the data frame of the selected set of identified TSRs in the returned
+#' \emph{tssObject}; note that the number of new columns is twice the number
+#' of replicates in the sample
 #'
+#' @importFrom stats median
 #' @importFrom utils write.table
 #'
 #' @examples
@@ -156,8 +158,11 @@ setMethod("addTagCountsToTSR",
                      } # end for (k ...
                  }
                  currentTSRset$cname <- countv
-                 colnames(currentTSRset)[which(names(currentTSRset) ==
-                 "cname")] <- experimentName@sampleNames[j]
+                 colnames(currentTSRset)[which(names(currentTSRset) == "cname")] <- experimentName@sampleNames[j]
+                 m <- pmax(median(countv[countv>0]),1)
+                 ncount <- round(100*pmin(countv/m,10),0)
+                 currentTSRset$cname <- ncount
+                 colnames(currentTSRset)[which(names(currentTSRset) == "cname")] <- paste("ncnt",experimentName@sampleNames[j],sep="")
 
               } # end for (j ...
               if (writeTable=="TRUE") {

--- a/R/detTSR.R
+++ b/R/detTSR.R
@@ -5,7 +5,7 @@
 #'
 #' @param experimentName - a S4 object of class tssObject containing
 #' information in slot tssTagData
-#' @param tsrSetType - specifies the set to be clustered. Options are
+#' @param tssSetType - specifies the set to be clustered. Options are
 #' "replicates" or "merged"
 #' @param tssSet - number of the dataset to be analyzed
 #' @param tagCountThreshold - number of TSSs required at a given position
@@ -22,7 +22,7 @@
 
 
 setGeneric("detTSR",
-    function(experimentName, tsrSetType, tssSet=1, tagCountThreshold,
+    function(experimentName, tssSetType, tssSet=1, tagCountThreshold,
              clustDist)
     standardGeneric("detTSR")
 )
@@ -33,18 +33,18 @@ setMethod("detTSR",
           signature(experimentName="tssObject", "character", "numeric",
                     "numeric", "numeric"),
 
-          function(experimentName, tsrSetType, tssSet,
+          function(experimentName, tssSetType, tssSet,
                    tagCountThreshold=1, clustDist) {
 
               message("... detTSR ...")
-              if (tsrSetType=="replicates") {
+              if (tssSetType=="replicates") {
                   if (tssSet>length(experimentName@tssCountData)) {
                       stop("The value selected for tssSet exceeds ",
                            "the number of slots in tssCountData.")
                   }
                   tss.df <- experimentName@tssCountData[[tssSet]]
               }
-              else if (tsrSetType=="merged") {
+              else if (tssSetType=="merged") {
                   if (length(experimentName@tssCountDataMerged)<1) {
                       stop("The @tssCountDataMerged slot is currently empty.",
                            "\nPlease complete the merger before continuing.")
@@ -56,7 +56,7 @@ setMethod("detTSR",
                   tss.df <- experimentName@tssCountDataMerged[[tssSet]]
               }
               else {
-                  stop("Error: argument tsrSetType to detTSR() should be ",
+                  stop("Error: argument tssSetType to detTSR() should be ",
                        "either \"replicates\" or \"merged\".")
               }
 

--- a/R/determineTSR.R
+++ b/R/determineTSR.R
@@ -6,7 +6,7 @@
 #' containing information in slot \emph{@@tssTagData}
 #' @param n.cores the number of cores to be used for this job.
 #' ncores=1 means serial execution of function calls (numeric)
-#' @param tsrSetType specifies the set to be clustered.
+#' @param tssSetType specifies the set to be clustered.
 #' Options are "replicates" or "merged". (character)
 #' @param tssSet default is "all"; if a single TSS dataset is desired,
 #' specify tssSet number (character)
@@ -26,7 +26,7 @@
 #' @examples
 #' load(system.file("extdata", "tssObjectExample.RData", package="TSRchitect"))
 #' tssObjectExample <- determineTSR(experimentName=tssObjectExample, n.cores=1,
-#' tsrSetType="replicates", tssSet="1", tagCountThreshold=25, clustDist=20,
+#' tssSetType="replicates", tssSet="1", tagCountThreshold=25, clustDist=20,
 #' writeTable=FALSE)
 #'
 #' @note An example similar to this one can be found in the vignette
@@ -35,7 +35,7 @@
 #' @rdname determineTSR-methods
 
 setGeneric("determineTSR",
-    function(experimentName, n.cores, tsrSetType, tssSet, tagCountThreshold,
+    function(experimentName, n.cores, tssSetType, tssSet, tagCountThreshold,
              clustDist, writeTable=FALSE)
     standardGeneric("determineTSR")
 )
@@ -46,18 +46,18 @@ setMethod("determineTSR",
           signature(experimentName="tssObject", "numeric", "character",
                     "character", "numeric", "numeric", "logical"),
 
-          function(experimentName, n.cores=1, tsrSetType=c("replicates",
+          function(experimentName, n.cores=1, tssSetType=c("replicates",
                    "merged"), tssSet="all", tagCountThreshold=1, clustDist=20,
                    writeTable=FALSE) {
 
              message("... determineTSR ...")
-             fileType <- match.arg(tsrSetType, several.ok=FALSE)
-             if (tsrSetType=="replicates") {
+             fileType <- match.arg(tssSetType, several.ok=FALSE)
+             if (tssSetType=="replicates") {
                  if (tssSet=="all") {
                      iend <- length(experimentName@tssCountData)
                      fcti <- function(i) {
                                 detTSR(experimentName,
-                                       tsrSetType="replicates",
+                                       tssSetType="replicates",
                                        tssSet=i,
                                        tagCountThreshold,
                                        clustDist)
@@ -75,6 +75,7 @@ setMethod("determineTSR",
                               writeTSR(experimentName,
                                        tsrSetType="replicates",
                                        tsrSet=i,
+                                       tsrLabel=paste("TSR",i,sep=""),
                                        fileType="tab")
                          }
                      }
@@ -87,25 +88,26 @@ setMethod("determineTSR",
                      }
                      experimentName@tsrData[[i]] <-
                          detTSR(experimentName = experimentName,
-                                tsrSetType="replicates",
+                                tssSetType="replicates",
                                 tssSet=i,
                                 tagCountThreshold,
                                 clustDist)
                      if (writeTable==TRUE) {
-                         writeTSR(experimentName = experimentName,
+                         writeTSR(experimentName,
                                   tsrSetType="replicates",
                                   tsrSet=i,
+                                  tsrLabel=paste("TSR",i,sep=""),
                                   fileType="tab")
                      }
                  }
              }
-             else if (tsrSetType=="merged") {
+             else if (tssSetType=="merged") {
                  iend <- length(experimentName@tssCountDataMerged)
                  if (tssSet=="all") {
                      iend <- length(experimentName@tssCountDataMerged)
                      fcti <- function(i) {
                                 detTSR(experimentName=experimentName,
-                                       tsrSetType="merged",
+                                       tssSetType="merged",
                                        tssSet=i,
                                        tagCountThreshold,
                                        clustDist)
@@ -120,10 +122,10 @@ setMethod("determineTSR",
                      }
                      if (writeTable==TRUE) {
                          for (i in 1:iend) {
-                              writeTSR(experimentName =
-                                       experimentName,
+                              writeTSR(experimentName,
                                        tsrSetType="merged",
                                        tsrSet=i,
+                                       tsrLabel=paste("mTSR",i,sep=""),
                                        fileType="tab")
                          }
                      }
@@ -136,14 +138,15 @@ setMethod("determineTSR",
                      }
                      experimentName@tsrDataMerged[[i]] <-
                          detTSR(experimentName = experimentName,
-                                tsrSetType="merged",
+                                tssSetType="merged",
                                 tssSet=i,
                                 tagCountThreshold,
                                 clustDist)
                      if (writeTable==TRUE) {
-                         writeTSR(experimentName = experimentName,
+                         writeTSR(experimentName,
                                   tsrSetType="merged",
                                   tsrSet=i,
+                                  tsrLabel=paste("mTSR",i,sep=""),
                                   fileType="tab")
                      }
                  }

--- a/R/makeGRangesFromTSR.R
+++ b/R/makeGRangesFromTSR.R
@@ -60,8 +60,8 @@ setMethod("makeGRangesFromTSR",
                       tsr.df <- experimentName@tsrDataMerged[[tsrSet]]
                   }
               else {
-                  stop("Error: argument tsrSetType to writeTSR() should be",
-                       "either \"replicates\" or \"merged\".")
+                  stop("Error: argument tsrSetType to nakeGRangesFromTSR() ",
+                       "should be either \"replicates\" or \"merged\".")
               }
               }
 

--- a/R/writeTSR.R
+++ b/R/writeTSR.R
@@ -129,7 +129,7 @@ setMethod("writeTSR",
               }
               else if (fileType == "bed") {
                   tsr.df$ID <- paste(tsrLabel,which(tsr.df$seq != ""),sep="_")
-                  m <- median(tsr.df$nTAGs)
+                  m <- pmax(median(tsr.df$nTAGs),1)
                   tsr.df$score <- round(100*pmin(tsr.df$nTAGs/m,10),0)
                   out.df <- tsr.df[, c("seq", "start", "end", "ID",
                                        "score", "strand")]
@@ -140,7 +140,7 @@ setMethod("writeTSR",
               else { # fileType == "gff") 
                   tsr.df$source <- rep("TSRchitect",nrow(tsr.df))
                   tsr.df$type <- rep("TSR",nrow(tsr.df))
-                  m <- median(tsr.df$nTAGs)
+                  m <- pmax(median(tsr.df$nTAGs),1)
                   tsr.df$score <- round(100*pmin(tsr.df$nTAGs/m,10),0)
                   tsr.df$phase <- rep(".",nrow(tsr.df))
                   tsr.df$ID <- paste("ID=",tsrLabel,"_",

--- a/man/addTagCountsToTSR-methods.Rd
+++ b/man/addTagCountsToTSR-methods.Rd
@@ -23,16 +23,17 @@ Options are "replicates" or "merged". (character)}
 \item{tsrSet}{number of the dataset to be processed, where 1 corresponds
 to the first slot, and so on. (numeric)}
 
-\item{tagCountThreshold}{number of TSSs required at a given position
-(numeric)}
+\item{tagCountThreshold}{number of tags required at a given TSS position in
+order to be included in the overall count for a TSR (numeric)}
 
 \item{writeTable}{specifies whether the output should be written to
 a table. (logical)}
 }
 \value{
-a matrix of tag counts (where the number of columns will equal
-the number of replicates in the sample) is appended to the data frame
-of the selected set of identified TSRs in the returned \emph{tssObject}
+a matrix of tag counts and median-normalized tag counts is appended
+to the data frame of the selected set of identified TSRs in the returned
+\emph{tssObject}; note that the number of new columns is twice the number
+of replicates in the sample
 }
 \description{
 \code{addTagCountsToTSR} adds a matrix of tag counts to a set

--- a/man/detTSR-methods.Rd
+++ b/man/detTSR-methods.Rd
@@ -6,18 +6,18 @@
 \alias{detTSR,tssObject,character,numeric,numeric,numeric-method}
 \title{detTSR}
 \usage{
-detTSR(experimentName, tsrSetType, tssSet = 1, tagCountThreshold,
+detTSR(experimentName, tssSetType, tssSet = 1, tagCountThreshold,
   clustDist)
 
 
   \S4method{detTSR}{tssObject,character,numeric,numeric,numeric}(experimentName,
-  tsrSetType, tssSet = 1, tagCountThreshold = 1, clustDist)
+  tssSetType, tssSet = 1, tagCountThreshold = 1, clustDist)
 }
 \arguments{
 \item{experimentName}{- a S4 object of class tssObject containing
 information in slot tssTagData}
 
-\item{tsrSetType}{- specifies the set to be clustered. Options are
+\item{tssSetType}{- specifies the set to be clustered. Options are
 "replicates" or "merged"}
 
 \item{tssSet}{- number of the dataset to be analyzed}

--- a/man/determineTSR-methods.Rd
+++ b/man/determineTSR-methods.Rd
@@ -6,12 +6,12 @@
 \alias{determineTSR,tssObject,numeric,character,character,numeric,numeric,logical-method}
 \title{\strong{determineTSR}}
 \usage{
-determineTSR(experimentName, n.cores, tsrSetType, tssSet,
+determineTSR(experimentName, n.cores, tssSetType, tssSet,
   tagCountThreshold, clustDist, writeTable = FALSE)
 
 
   \S4method{determineTSR}{tssObject,numeric,character,character,numeric,numeric,logical}(experimentName,
-  n.cores = 1, tsrSetType = c("replicates", "merged"),
+  n.cores = 1, tssSetType = c("replicates", "merged"),
   tssSet = "all", tagCountThreshold = 1, clustDist = 20,
   writeTable = FALSE)
 }
@@ -22,7 +22,7 @@ containing information in slot \emph{@tssTagData}}
 \item{n.cores}{the number of cores to be used for this job.
 ncores=1 means serial execution of function calls (numeric)}
 
-\item{tsrSetType}{specifies the set to be clustered.
+\item{tssSetType}{specifies the set to be clustered.
 Options are "replicates" or "merged". (character)}
 
 \item{tssSet}{default is "all"; if a single TSS dataset is desired,
@@ -53,7 +53,7 @@ An example similar to this one can be found in the vignette
 \examples{
 load(system.file("extdata", "tssObjectExample.RData", package="TSRchitect"))
 tssObjectExample <- determineTSR(experimentName=tssObjectExample, n.cores=1,
-tsrSetType="replicates", tssSet="1", tagCountThreshold=25, clustDist=20,
+tssSetType="replicates", tssSet="1", tagCountThreshold=25, clustDist=20,
 writeTable=FALSE)
 
 }

--- a/man/loadTSSobj-methods.Rd
+++ b/man/loadTSSobj-methods.Rd
@@ -34,7 +34,10 @@ http://bedtools.readthedocs.io/en/latest/content/general-usage.html}
 
 \item{sampleSheet}{file providing TSS sample information; if provided,
 sampleNames and replicateIDs are ignored; input format is tab-delimited
-3-column rows with sample name, replicate ID, and sample data file name}
+3-column rows with sample name, replicate ID, and sample data file name;
+the file has to include column headers "SAMPLE    ReplicateID    FILE"
+and can be either tab-delimited or an Excel spreadsheet (file extension
+".xls" or "xlsx" (character)}
 
 \item{sampleNames}{unique labels of class character for each TSS sample
 within the experiment (character).}

--- a/vignettes/TSRchitect.Rmd
+++ b/vignettes/TSRchitect.Rmd
@@ -86,7 +86,7 @@ tssSet="all".
 
 ```{r eval=TRUE}
 tssObjectExample <- determineTSR(experimentName=tssObjectExample, n.cores=1,
-tsrSetType="replicates", tssSet="all", tagCountThreshold=25, clustDist=20,
+tssSetType="replicates", tssSet="all", tagCountThreshold=25, clustDist=20,
 writeTable=FALSE)
 ```
 
@@ -97,7 +97,7 @@ We then use `addTagCountsToTSR` to quantify the number of tags found in each of 
 tssObjectExample <- mergeSampleData(experimentName=tssObjectExample)
 
 tssObjectExample <- determineTSR(experimentName=tssObjectExample, n.cores=1,
-tsrSetType="merged", tssSet="all", tagCountThreshold=25, clustDist=20,
+tssSetType="merged", tssSet="all", tagCountThreshold=25, clustDist=20,
 writeTable=FALSE)
 
 tssObjectExample <- addTagCountsToTSR(experimentName=tssObjectExample,


### PR DESCRIPTION
…ble where appropriate

Comments:
1) writeTSR now includes the variable "tsrLabel", and that was left out in writeTSR calls from other functions; now fixed

2) TSRs are derived from TSS sets; thus it is much cleaner to use tssSetType to describe the input type (replicate or merged) for determineTSR()

3) The pull request also addresses minor formatting/output problems