### PR TITLE
Updated references to version 1.12.0 as required by Bioconductor.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: TSRchitect
-Version: 1.10.0
+Version: 1.12.0
 Date: 2019-09-17
 Title: Promoter identification from large-scale TSS profiling data
 Description: In recent years, large-scale transcriptional sequence data has

--- a/NEWS
+++ b/NEWS
@@ -21,7 +21,7 @@
 1.8.9 (10-08-2018)
 + Updates that correct a speed issue encountered when analyzing data aligned to assemblies with many scaffolds.
 + Simplified part of one vignette.
-1.10.0 (09-17-2019)
+1.12.0 (09-17-2019)
 + Updates to include 3'-read capturing from bam input files and data structures to allow ignoring spurious TSSs.
 + Added capabilities for sorting by strand (and seq/TSS) for TSS merging.
 + Made a change leading to a substantial speed-up of mergeSampleData().

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For example, in that console, you should see
 R version 3.5.3 (2019-03-11) -- "Great Truth"
 ...
 > packageVersion("TSRchitect")
-[1] '1.10.0'
+[1] '1.12.0'
 >
 ```
 


### PR DESCRIPTION
- After sync with Bioconductor repo in preparation for submission of recent updates, learned that version needs to be changed to 1.12.0 because of automatic version bumps by BioC.
- Updated references to version in DESCRIPTION, NEWS, and README.md.
- Once merged I will submit to this branch to the Bioconductor git repo.