### PR TITLE
Corrected version to 1.10.10 in accordance with BioC policies.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: TSRchitect
-Version: 1.12.0
+Version: 1.10.10
 Date: 2019-09-17
 Title: Promoter identification from large-scale TSS profiling data
 Description: In recent years, large-scale transcriptional sequence data has

--- a/NEWS
+++ b/NEWS
@@ -21,7 +21,7 @@
 1.8.9 (10-08-2018)
 + Updates that correct a speed issue encountered when analyzing data aligned to assemblies with many scaffolds.
 + Simplified part of one vignette.
-1.12.0 (09-17-2019)
+1.10.10 (09-17-2019)
 + Updates to include 3'-read capturing from bam input files and data structures to allow ignoring spurious TSSs.
 + Added capabilities for sorting by strand (and seq/TSS) for TSS merging.
 + Made a change leading to a substantial speed-up of mergeSampleData().

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For example, in that console, you should see
 R version 3.5.3 (2019-03-11) -- "Great Truth"
 ...
 > packageVersion("TSRchitect")
-[1] '1.12.0'
+[1] '1.10.10'
 >
 ```
 


### PR DESCRIPTION
- According to the versioning system x.y.z, only z can be changed by the maintainer/developer. 
- Updates to the current release with a change to z in the description will trigger a new bioconductor build.
- y will be changed by Bioconductor at the point of every release: 2x per year.
Please see [http://bioconductor.org/developers/how-to/version-numbering/](here) for further reference.