### PR TITLE
Corrected logicals in loadTSSobj.R that were triggering a build error.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: TSRchitect
-Version: 1.13.4
-Date: 2019-12-16
+Version: 1.13.5
+Date: 2020-3-27
 Title: Promoter identification from large-scale TSS profiling data
 Description: In recent years, large-scale transcriptional sequence data has
     yielded considerable insights into the nature of gene expression and regulation

--- a/NEWS
+++ b/NEWS
@@ -39,4 +39,5 @@
 + Updated documentation for loadTSSobj() for the sake of clarity.
 1.13.4 (12-16-2019)
 + Added feature to writeTSS() that generates two separate bedgraph files (plus and minus) instead of one.
-
+1.13.5 (3-30-2020)
++ Corrected line in loadTSSobj() that caused a build error in the Bioc devel branch (3.11).

--- a/R/loadTSSobj.R
+++ b/R/loadTSSobj.R
@@ -105,8 +105,19 @@ setMethod("loadTSSobj",
                 }
               }
 
-              if (is.na(sampleNames)  || !is.character(sampleNames) ||
-                  is.na(replicateIDs) || !is.numeric(replicateIDs)    ) {
+              if (is.na(sampleNames))  {
+                stop("You must specify both sample names (as \"character\")",
+                     " and replicate IDs (as \"numeric\").  Please check.")
+              }
+              if (!is.character(sampleNames)) {
+                stop("You must specify both sample names (as \"character\")",
+                     " and replicate IDs (as \"numeric\").  Please check.")
+              }
+              if (!is.numeric(replicateIDs)) {
+                stop("You must specify both sample names (as \"character\")",
+                     " and replicate IDs (as \"numeric\").  Please check.")
+              }
+              if (!is.numeric(replicateIDs)) {
                 stop("You must specify both sample names (as \"character\")",
                      " and replicate IDs (as \"numeric\").  Please check.")
               }

--- a/R/loadTSSobj.R
+++ b/R/loadTSSobj.R
@@ -105,21 +105,12 @@ setMethod("loadTSSobj",
                 }
               }
 
-              if (is.na(sampleNames))  {
-                stop("You must specify both sample names (as \"character\")",
-                     " and replicate IDs (as \"numeric\").  Please check.")
+	      if (anyNA(sampleNames)  | !is.character(sampleNames) |
+              	 anyNA(replicateIDs) | !is.numeric(replicateIDs)    ) {
+		   stop("You must specify both sample names (as \"character\")",
+                        " and replicate IDs (as \"numeric\").  Please check.")
               }
-              if (!is.character(sampleNames)) {
-                stop("You must specify both sample names (as \"character\")",
-                     " and replicate IDs (as \"numeric\").  Please check.")
-              }
-              if (!is.numeric(replicateIDs)) {
-                stop("You must specify both sample names (as \"character\")",
-                     " and replicate IDs (as \"numeric\").  Please check.")
-              }
-              if (!is.numeric(replicateIDs)) {
-                stop("You must specify both sample names (as \"character\")",
-                     " and replicate IDs (as \"numeric\").  Please check.")
+
               }
               if (!missing(n.cores) & n.cores > 1) {
                   BiocParallel::register(MulticoreParam(workers=n.cores),

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For example, in that console, you should see
 R version 3.5.3 (2019-03-11) -- "Great Truth"
 ...
 > packageVersion("TSRchitect")
-[1] '1.13.4'
+[1] '1.13.5'
 >
 ```
 


### PR DESCRIPTION
- Recently on the devel branch of Bioconductor (Bioc 3.11), there were changes made to the automatic build that trigger build errors in certain instances. This change meant that logicals in `loadTSSobj()` was triggering  build errors.
- I changed this and updated the version of TSRhitect to '1.13.5' to reflect this change.

