### PR TITLE
Updating master (i.e. the Bioc devel branch) due to release of BioC 3.11

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: TSRchitect
-Version: 1.15.0
+Version: 1.15.1
 Date: 2020-3-27
 Title: Promoter identification from large-scale TSS profiling data
 Description: In recent years, large-scale transcriptional sequence data has

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: TSRchitect
-Version: 1.13.5
+Version: 1.14.0
 Date: 2020-3-27
 Title: Promoter identification from large-scale TSS profiling data
 Description: In recent years, large-scale transcriptional sequence data has

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: TSRchitect
-Version: 1.14.0
+Version: 1.15.0
 Date: 2020-3-27
 Title: Promoter identification from large-scale TSS profiling data
 Description: In recent years, large-scale transcriptional sequence data has

--- a/NEWS
+++ b/NEWS
@@ -41,3 +41,5 @@
 + Added feature to writeTSS() that generates two separate bedgraph files (plus and minus) instead of one.
 1.13.5 (3-30-2020)
 + Corrected line in loadTSSobj() that caused a build error in the Bioc devel branch (3.11).
+1.15.1 (3-27-2020)
++ Version bump due to release of Bioconductor v. 3.11.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For example, in that console, you should see
 R version 3.5.3 (2019-03-11) -- "Great Truth"
 ...
 > packageVersion("TSRchitect")
-[1] '1.13.5'
+[1] '1.15.1'
 >
 ```
 


### PR DESCRIPTION
- syncing our master with Bioc's devel branch after their move to version 3.11 (3.12 for devel) last month.
- the TSRchitect release version was updated to 1.15.1
- updated `DESCRIPTION`, `NEWS` and `README.md` to reflect the above